### PR TITLE
fix(xtask): binary path resolution and mutex poison recovery (#6)

### DIFF
--- a/xtask/src/conform_real.rs
+++ b/xtask/src/conform_real.rs
@@ -1294,33 +1294,41 @@ fn test_data_diffguard_shape() -> Result<()> {
 
 /// Get the path to the diffguard binary.
 fn cargo_bin_path() -> String {
-    // Use cargo to find the binary
+    // Prefer env var if it points to the actual diffguard binary
+    // (not xtask, which is what CARGO_BIN_EXE_diffguard points to
+    // when running `cargo test -p xtask`)
     if let Ok(bin) = std::env::var("CARGO_BIN_EXE_diffguard") {
-        return bin;
+        if bin.contains("diffguard") && !bin.contains("xtask") {
+            return bin;
+        }
     }
 
-    // Fall back to building and finding in target/debug
+    // Fall back to workspace-relative target/debug path
     let _ = ensure_diffguard_built();
-    let binary = workspace_root()
+    workspace_root()
         .join("target")
         .join("debug")
         .join(if cfg!(windows) {
             "diffguard.exe"
         } else {
             "diffguard"
-        });
-    binary.to_string_lossy().into_owned()
+        })
+        .to_string_lossy()
+        .into_owned()
 }
 
 /// Run diffguard with the given arguments.
 fn run_diffguard(dir: &Path, args: &[&str]) -> Result<Output> {
+    // Prefer env var if it points to the actual diffguard binary
     if let Ok(bin) = std::env::var("CARGO_BIN_EXE_diffguard") {
-        let output = Command::new(bin)
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .context("run diffguard")?;
-        return Ok(output);
+        if bin.contains("diffguard") && !bin.contains("xtask") {
+            let output = Command::new(bin)
+                .args(args)
+                .current_dir(dir)
+                .output()
+                .context("run diffguard")?;
+            return Ok(output);
+        }
     }
 
     ensure_diffguard_built()?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -167,6 +167,11 @@ mod tests {
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+    /// Lock the ENV mutex, recovering from poison if needed.
+    fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     #[cfg(windows)]
     fn ok_command() -> (&'static str, Vec<&'static str>) {
         ("cmd", vec!["/C", "exit 0"])
@@ -315,7 +320,7 @@ mod tests {
 
     #[test]
     fn run_with_args_dispatches_ci_with_fake_cargo() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = lock_env();
         let dir = TempDir::new().expect("temp");
         let bin_dir = dir.path().join("bin");
         std::fs::create_dir_all(&bin_dir).expect("create bin dir");
@@ -363,7 +368,7 @@ mod tests {
 
     #[test]
     fn ci_reports_failure_when_clippy_fails() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = lock_env();
         let dir = TempDir::new().expect("temp");
         let bin_dir = dir.path().join("bin");
         std::fs::create_dir_all(&bin_dir).expect("create bin dir");


### PR DESCRIPTION
## Fix #6: xtask binary path resolution

### Problem
`cargo test -p xtask` fails because `CARGO_BIN_EXE_diffguard` points to the xtask test binary, not the actual diffguard binary when running tests from the xtask package.

### Changes

**`conform_real.rs`:**
- `cargo_bin_path()`: validate env var actually contains "diffguard" and not "xtask" before using it; fall back to workspace `target/debug/diffguard` path; auto-build if missing
- `run_diffguard()`: same validation of env var before using it

**`main.rs`:**
- Add `lock_env()` helper that recovers from poisoned mutex (`unwrap_or_else(|e| e.into_inner())`) instead of panicking, preventing cascade failures between tests that use `ENV_LOCK`

### Verification
- xtask tests: 11 passed, 0 failed
- CI simulation passes
