### PR TITLE
fix: LSP git diff subprocess timeout (#13)

### DIFF
--- a/crates/diffguard-lsp/src/server.rs
+++ b/crates/diffguard-lsp/src/server.rs
@@ -1,6 +1,8 @@
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
 use diffguard_core::{CheckPlan, run_check};
@@ -915,7 +917,29 @@ fn run_git_diff(workspace_root: &Path, relative_path: &str, staged: bool) -> Res
     }
     command.arg("--unified=0").arg("--").arg(relative_path);
 
-    let output = command.output().context("run git diff")?;
+    // Spawn with a 10-second timeout to avoid blocking the LSP indefinitely
+    const GIT_DIFF_TIMEOUT: Duration = Duration::from_secs(10);
+    let mut child = command.spawn().context("spawn git diff")?;
+    let deadline = Instant::now() + GIT_DIFF_TIMEOUT;
+
+    let output = loop {
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                // Process has exited; wait_with_output() returns immediately
+                break child.wait_with_output().context("wait for git diff")?;
+            }
+            Ok(None) => {
+                // Still running
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    bail!("git diff timed out after {}s", GIT_DIFF_TIMEOUT.as_secs());
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+            Err(e) => bail!("checking git diff status: {e}"),
+        }
+    };
+
     if !output.status.success() {
         bail!(
             "git diff failed (exit={}): {}",

--- a/crates/diffguard/src/main.rs
+++ b/crates/diffguard/src/main.rs
@@ -4584,6 +4584,9 @@ should_match = true
 
     #[test]
     fn cmd_validate_accepts_valid_globs_and_strict_no_warnings() {
+        // Acquire ENV_LOCK to prevent DIFFGUARD_TEST_FORCE_COMPILE_ERROR from
+        // leaking from cmd_validate_forced_compile_error when tests run in parallel.
+        let _guard = ENV_LOCK.lock().unwrap();
         let dir = TempDir::new().unwrap();
         let config_path = write_config(
             dir.path(),


### PR DESCRIPTION
## Fix #13: LSP git diff subprocess timeout

### Problem
`Command::new("git").output()` blocks the LSP server indefinitely on large repos. No timeout configured.

### Fix
Changed `run_git_diff()` in `crates/diffguard-lsp/src/server.rs`:
- Spawn the process + poll `try_wait()` in a loop (100ms intervals)
- 10-second maximum timeout before killing the child process
- No new dependencies required (uses only `std::process::Command`, `std::thread`, `std::time::Instant`)

### Verification
```
cargo build -p diffguard-lsp   ✓  
cargo clippy -p diffguard-lsp  ✓
cargo fmt --check              ✓
cargo test -p diffguard-lsp    ✓  (9 tests)
```

### Also included
Fixes a race condition in `cmd_validate` test by adding `ENV_LOCK` to prevent parallel test interference