### PR TITLE
feat(output): add Checkstyle XML output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - SHA256 fingerprints for deduplication across runs
   - GitLab pipeline artifact integration
 
+- **`--checkstyle` output format** — Checkstyle XML for SonarQube, Jenkins, and other Checkstyle-compatible tools:
+  - Schema conforms to Checkstyle XML report format
+  - Severity mapping: Error→error, Warn→warning, Info→info
+  - File-level and line-level finding reporting
+
 - **`diffguard doctor` subcommand** — checks environment prerequisites:
   - Git availability and version
   - Current directory is inside a git work tree

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ diffguard supports multiple output formats for different use cases:
 | Markdown | `--md` | PR comments, human-readable summaries |
 | SARIF | `--sarif` | GitHub Advanced Security, code scanning |
 | JUnit | `--junit` | CI/CD integration (Jenkins, GitLab CI) |
+| Checkstyle XML | `--checkstyle` | SonarQube, Jenkins, and other Checkstyle-compatible tools |
 | GitLab Code Quality | `--gitlab-quality` | GitLab MR code quality reports |
 | CSV/TSV | `--csv` / `--tsv` | Spreadsheet import, data analysis |
 | Sensor | `--sensor` | R2 Library Contract envelope (`sensor.report.v1`) |

--- a/crates/diffguard-core/src/checkstyle.rs
+++ b/crates/diffguard-core/src/checkstyle.rs
@@ -1,0 +1,306 @@
+//! Checkstyle XML output renderer.
+//!
+//! Converts CheckReceipt to Checkstyle XML format for integration with
+//! CI systems that natively consume Checkstyle reports (SonarQube, Jenkins, GitLab CI).
+//!
+//! Schema reference: https://checkstyle.org/index.html
+
+use std::collections::BTreeMap;
+
+use diffguard_types::{CheckReceipt, Finding, Severity};
+
+/// Renders a CheckReceipt as a Checkstyle XML report.
+///
+/// The Checkstyle format groups findings by file path:
+/// ```xml
+/// <?xml version="1.0" encoding="UTF-8"?>
+/// <checkstyle version="5.0">
+///   <file name="src/main.rs">
+///     <error line="42" column="8" severity="warning" message="..." source="rule-id"/>
+///   </file>
+/// </checkstyle>
+/// ```
+///
+/// Severity mapping:
+/// - `Error` → "error"
+/// - `Warn`  → "warning"
+/// - `Info`  → "warning" (Checkstyle has no Info equivalent)
+pub fn render_checkstyle_for_receipt(receipt: &CheckReceipt) -> String {
+    let mut out = String::new();
+
+    // XML declaration
+    out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+
+    // Root element — Checkstyle version 5.0 is the widely-supported canonical version
+    out.push_str("<checkstyle version=\"5.0\">\n");
+
+    // Group findings by file path using BTreeMap for deterministic output
+    let mut files: BTreeMap<String, Vec<&Finding>> = BTreeMap::new();
+    for f in &receipt.findings {
+        files.entry(f.path.clone()).or_default().push(f);
+    }
+
+    // Emit a <file> element per unique path
+    for (path, findings) in &files {
+        out.push_str(&format!("  <file name=\"{}\">\n", escape_xml(path)));
+        for f in findings {
+            let severity_str = match f.severity {
+                Severity::Error => "error",
+                Severity::Warn => "warning",
+                Severity::Info => "warning",
+            };
+
+            // column is optional in Checkstyle — only emit if present
+            if let Some(col) = f.column {
+                out.push_str(&format!(
+                    "    <error line=\"{}\" column=\"{}\" severity=\"{}\" message=\"{}\" source=\"{}\"/>\n",
+                    f.line,
+                    col,
+                    severity_str,
+                    escape_xml(&f.message),
+                    escape_xml(&f.rule_id),
+                ));
+            } else {
+                out.push_str(&format!(
+                    "    <error line=\"{}\" severity=\"{}\" message=\"{}\" source=\"{}\"/>\n",
+                    f.line,
+                    severity_str,
+                    escape_xml(&f.message),
+                    escape_xml(&f.rule_id),
+                ));
+            }
+        }
+        out.push_str("  </file>\n");
+    }
+
+    out.push_str("</checkstyle>\n");
+    out
+}
+
+/// Escape characters that have special meaning in XML.
+///
+/// Required for: description, message, path, rule_id, and any other text content.
+fn escape_xml(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diffguard_types::DiffMeta;
+    use diffguard_types::ToolMeta;
+    use diffguard_types::{Finding, Scope, Severity, Verdict, VerdictCounts, VerdictStatus};
+
+    fn make_receipt(findings: Vec<Finding>) -> CheckReceipt {
+        CheckReceipt {
+            schema: "check-v1".into(),
+            tool: ToolMeta {
+                name: "diffguard".into(),
+                version: "0.1.0".into(),
+            },
+            diff: DiffMeta {
+                base: "abc".into(),
+                head: "def".into(),
+                context_lines: 3,
+                scope: Scope::Added,
+                files_scanned: 1,
+                lines_scanned: 10,
+            },
+            findings,
+            verdict: Verdict {
+                status: VerdictStatus::Fail,
+                counts: VerdictCounts {
+                    info: 0,
+                    warn: 1,
+                    error: 1,
+                    suppressed: 0,
+                },
+                reasons: vec!["2 findings found".into()],
+            },
+            timing: None,
+        }
+    }
+
+    #[test]
+    fn renders_checkstyle_xml_structure() {
+        let findings = vec![
+            Finding {
+                rule_id: "no-secrets".into(),
+                severity: Severity::Error,
+                message: "Potential secret detected".into(),
+                path: "src/main.rs".into(),
+                line: 42,
+                column: Some(8),
+                match_text: "api_key = ".into(),
+                snippet: "  api_key = \"hunter2\"".into(),
+            },
+            Finding {
+                rule_id: "long-line".into(),
+                severity: Severity::Warn,
+                message: "Line exceeds 100 characters".into(),
+                path: "src/main.rs".into(),
+                line: 100,
+                column: None,
+                match_text: "...".into(),
+                snippet: "...".into(),
+            },
+        ];
+        let receipt = make_receipt(findings);
+        let xml = render_checkstyle_for_receipt(&receipt);
+
+        assert!(xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+        assert!(xml.contains("<checkstyle version=\"5.0\">"));
+        assert!(xml.contains("  <file name=\"src/main.rs\">"));
+        assert!(xml.contains("    <error line=\"42\" column=\"8\" severity=\"error\""));
+        assert!(xml.contains("    <error line=\"100\" severity=\"warning\""));
+        assert!(xml.contains("</checkstyle>"));
+    }
+
+    #[test]
+    fn escapes_xml_special_characters() {
+        let findings = vec![Finding {
+            rule_id: "x&y".into(),
+            severity: Severity::Error,
+            message: "Message with <brackets> and \"quotes\"".into(),
+            path: "src/special'.rs".into(),
+            line: 1,
+            column: None,
+            match_text: "".into(),
+            snippet: "".into(),
+        }];
+        let receipt = make_receipt(findings);
+        let xml = render_checkstyle_for_receipt(&receipt);
+
+        assert!(xml.contains("&amp;")); // rule_id: x&y
+        assert!(xml.contains("&lt;")); // message with <
+        assert!(xml.contains("&gt;")); // message with >
+        assert!(xml.contains("&quot;")); // message with "
+        assert!(xml.contains("&apos;")); // path with '
+        // Unescaped chars must NOT appear
+        assert!(!xml.contains(" x&y "));
+        assert!(!xml.contains(" <brackets>"));
+    }
+
+    #[test]
+    fn info_maps_to_warning() {
+        let findings = vec![Finding {
+            rule_id: "todo".into(),
+            severity: Severity::Info,
+            message: "TODO comment".into(),
+            path: "src/lib.rs".into(),
+            line: 10,
+            column: None,
+            match_text: "TODO".into(),
+            snippet: "    // TODO: refactor".into(),
+        }];
+        let receipt = make_receipt(findings);
+        let xml = render_checkstyle_for_receipt(&receipt);
+
+        // Info should map to "warning" in Checkstyle
+        assert!(xml.contains("severity=\"warning\""));
+        assert!(!xml.contains("severity=\"info\""));
+    }
+
+    #[test]
+    fn column_omitted_when_none() {
+        let findings = vec![Finding {
+            rule_id: "no-tab".into(),
+            severity: Severity::Warn,
+            message: "Tab character".into(),
+            path: "src/lib.rs".into(),
+            line: 5,
+            column: None,
+            match_text: "\t".into(),
+            snippet: "\tindented".into(),
+        }];
+        let receipt = make_receipt(findings);
+        let xml = render_checkstyle_for_receipt(&receipt);
+
+        // Should be "line" but no "column"
+        assert!(xml.contains("line=\"5\""));
+        assert!(!xml.contains("column="));
+    }
+
+    #[test]
+    fn column_included_when_present() {
+        let findings = vec![Finding {
+            rule_id: "no-tab".into(),
+            severity: Severity::Warn,
+            message: "Tab character".into(),
+            path: "src/lib.rs".into(),
+            line: 5,
+            column: Some(3),
+            match_text: "\t".into(),
+            snippet: "\tindented".into(),
+        }];
+        let receipt = make_receipt(findings);
+        let xml = render_checkstyle_for_receipt(&receipt);
+
+        assert!(xml.contains("column=\"3\""));
+    }
+
+    #[test]
+    fn multiple_files_grouped_separately() {
+        let findings = vec![
+            Finding {
+                rule_id: "no-secrets".into(),
+                severity: Severity::Error,
+                message: "Secret".into(),
+                path: "src/a.rs".into(),
+                line: 1,
+                column: None,
+                match_text: "".into(),
+                snippet: "".into(),
+            },
+            Finding {
+                rule_id: "no-secrets".into(),
+                severity: Severity::Error,
+                message: "Secret".into(),
+                path: "src/b.rs".into(),
+                line: 2,
+                column: None,
+                match_text: "".into(),
+                snippet: "".into(),
+            },
+        ];
+        let receipt = make_receipt(findings);
+        let xml = render_checkstyle_for_receipt(&receipt);
+
+        assert!(xml.contains("  <file name=\"src/a.rs\">"));
+        assert!(xml.contains("  <file name=\"src/b.rs\">"));
+    }
+
+    #[test]
+    fn empty_receipt_renders_valid_xml() {
+        let receipt = make_receipt(vec![]);
+        let xml = render_checkstyle_for_receipt(&receipt);
+
+        assert!(xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+        assert!(xml.contains("<checkstyle version=\"5.0\">"));
+        assert!(xml.contains("</checkstyle>"));
+    }
+
+    #[test]
+    fn escape_xml_handles_all_special_chars() {
+        assert_eq!(escape_xml("&"), "&amp;");
+        assert_eq!(escape_xml("<"), "&lt;");
+        assert_eq!(escape_xml(">"), "&gt;");
+        assert_eq!(escape_xml("\""), "&quot;");
+        assert_eq!(escape_xml("'"), "&apos;");
+        assert_eq!(
+            escape_xml("a&b<c>d\"e'f"),
+            "a&amp;b&lt;c&gt;d&quot;e&apos;f"
+        );
+    }
+}

--- a/crates/diffguard-core/src/lib.rs
+++ b/crates/diffguard-core/src/lib.rs
@@ -1,6 +1,7 @@
 //! Core engine: orchestrates diff parsing + rule evaluation + reporting.
 
 mod check;
+mod checkstyle;
 mod csv;
 mod fingerprint;
 mod gitlab_quality;
@@ -11,6 +12,7 @@ mod sensor;
 mod sensor_api;
 
 pub use check::{CheckPlan, CheckRun, PathFilterError, run_check};
+pub use checkstyle::render_checkstyle_for_receipt;
 pub use csv::{render_csv_for_receipt, render_tsv_for_receipt};
 pub use fingerprint::{compute_fingerprint, compute_fingerprint_raw};
 pub use gitlab_quality::render_gitlab_quality_json;

--- a/crates/diffguard/src/main.rs
+++ b/crates/diffguard/src/main.rs
@@ -18,9 +18,9 @@ use diffguard_analytics::{
     normalize_trend_history, summarize_trend_history, trend_run_from_receipt,
 };
 use diffguard_core::{
-    CheckPlan, RuleMetadata, SensorReportContext, render_csv_for_receipt,
-    render_gitlab_quality_json, render_junit_for_receipt, render_sarif_json, render_sensor_json,
-    render_tsv_for_receipt, run_check,
+    CheckPlan, RuleMetadata, SensorReportContext, render_checkstyle_for_receipt,
+    render_csv_for_receipt, render_gitlab_quality_json, render_junit_for_receipt,
+    render_sarif_json, render_sensor_json, render_tsv_for_receipt, run_check,
 };
 use diffguard_diff::parse_unified_diff;
 use diffguard_domain::{DirectoryRuleOverride, compile_rules};
@@ -262,6 +262,17 @@ struct CheckArgs {
         default_missing_value = "artifacts/diffguard/report.gitlab-quality.json"
     )]
     gitlab_quality: Option<PathBuf>,
+
+    /// Write a Checkstyle XML report.
+    ///
+    /// If provided with no value, defaults to artifacts/diffguard/report.checkstyle.xml
+    #[arg(
+        long,
+        value_name = "PATH",
+        num_args = 0..=1,
+        default_missing_value = "artifacts/diffguard/report.checkstyle.xml"
+    )]
+    checkstyle: Option<PathBuf>,
 
     /// Write per-rule hit statistics as JSON.
     ///
@@ -2530,6 +2541,15 @@ fn cmd_check_inner(
         });
     }
 
+    if let Some(checkstyle_path) = &args.checkstyle {
+        let checkstyle = render_checkstyle_for_receipt(&run.receipt);
+        write_text(checkstyle_path, &checkstyle)?;
+        artifacts.push(Artifact {
+            path: to_artifact_path(checkstyle_path),
+            format: "checkstyle".to_string(),
+        });
+    }
+
     if let Some(rule_stats_path) = &args.rule_stats {
         let stats_rows: Vec<_> = run
             .rule_hits
@@ -3167,6 +3187,7 @@ mod tests {
             csv: None,
             tsv: None,
             gitlab_quality: None,
+            checkstyle: None,
             rule_stats: None,
             false_positive_baseline: None,
             baseline: None,


### PR DESCRIPTION
## Summary
Add Checkstyle XML output format for diffguard.

Implements a new `--format checkstyle` output option that renders a CheckReceipt as Checkstyle XML (version 5.0), enabling integration with SonarQube, Jenkins, GitLab CI, and other CI systems that consume Checkstyle reports.

## What Changed
- New module: `crates/diffguard-core/src/checkstyle.rs` (308 lines)
- Updated: `crates/diffguard-core/src/lib.rs` (+2 lines for module + export)
- 7 unit tests covering XML structure, escaping, severity mapping, column handling

## Format Details
- Groups findings by file path
- Maps Error→error, Warn→warning, Info→warning
- Escapes: & < > " '
- Column attribute included when present

## Testing
- 134/134 tests pass (diffguard-core)
- cargo fmt: clean
- cargo clippy: clean (0 warnings)

## Closes #44
