### PR TITLE
feat(cli): add --version flag to print version from Cargo.toml

### DIFF
--- a/adr-010-version-flag.md
+++ b/adr-010-version-flag.md
@@ -1,0 +1,58 @@
+# ADR-010: Add `--version` Flag to DiffGuard CLI
+
+**Status:** Accepted
+
+**Date:** 2026-04-09
+
+**Work Item:** work-3b090538
+
+---
+
+## Context
+
+Issue #47 requests a `--version` flag that prints the version string from `Cargo.toml`. DiffGuard currently lacks this basic CLI feature, which is expected by all users — especially in CI environments where version verification is common.
+
+---
+
+## Decision
+
+Add `#[command(version)]` attribute to the `Cli` struct. Clap 4.x automatically derives `--version` (and `-V`) flags from `CARGO_PKG_VERSION`, which is set at compile time from `Cargo.toml` metadata.
+
+**Implementation:**
+- Add `#[command(version)]` above `#[derive(Parser)]` on the `Cli` struct
+- No runtime parsing or I/O needed
+- Version string matches `CARGO_PKG_VERSION` exactly
+
+---
+
+## Alternatives Considered
+
+### 1. Manual version string parsing
+Read version from `Cargo.toml` at runtime — unnecessary complexity since clap provides this for free.
+
+### 2. `env!()` macro in a `--version` subcommand
+Define a custom version subcommand using `env!("CARGO_PKG_VERSION")` — more code than needed.
+
+### 3. `clap::crate_version!()` macro
+Call `clap::crate_version!()` explicitly — equivalent to `#[command(version)]` but more verbose.
+
+---
+
+## Consequences
+
+**Positive:**
+- Single attribute addition, zero logic changes
+- Standard CLI convention followed
+- CI scripts can verify version before running
+
+**Negative:**
+- None
+
+**Neutral:**
+- The version string is already embedded in the binary via `CARGO_PKG_VERSION`
+
+---
+
+## Files Affected
+
+- `crates/diffguard/src/main.rs` — add `#[command(version)]` to `Cli` struct

--- a/crates/diffguard/src/main.rs
+++ b/crates/diffguard/src/main.rs
@@ -41,6 +41,7 @@ use presets::Preset;
 #[derive(Parser)]
 #[command(name = "diffguard")]
 #[command(about = "Diff-scoped governance lint", long_about = None)]
+#[command(version)]
 struct Cli {
     /// Enable verbose (info-level) logging to stderr.
     #[arg(long, short = 'v', global = true)]

--- a/crates/diffguard/tests/cli_misc.rs
+++ b/crates/diffguard/tests/cli_misc.rs
@@ -358,3 +358,49 @@ fn validate_without_config_errors() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("No configuration file found"));
 }
+
+#[test]
+fn test_version_flag_long_form() {
+    let output = diffguard_cmd()
+        .arg("--version")
+        .output()
+        .expect("run diffguard --version");
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.starts_with("diffguard "), "version output should start with 'diffguard ': {}", stdout);
+    // Version should be semver-like (e.g., "0.2.0" or "0.2.0-alpha")
+    assert!(stdout.trim().ends_with("diffguard")
+        || stdout.trim().matches(char::is_numeric).count() >= 2,
+        "version string should contain numbers: {}", stdout);
+}
+
+#[test]
+fn test_version_flag_short_form() {
+    let output = diffguard_cmd()
+        .arg("-V")
+        .output()
+        .expect("run diffguard -V");
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.starts_with("diffguard "), "version output should start with 'diffguard ': {}", stdout);
+}
+
+#[test]
+fn test_version_matches_cargo_toml() {
+    // Verify --version and -V produce consistent output
+    let long_output = diffguard_cmd()
+        .arg("--version")
+        .output()
+        .expect("run diffguard --version");
+
+    let short_output = diffguard_cmd()
+        .arg("-V")
+        .output()
+        .expect("run diffguard -V");
+
+    assert_eq!(long_output.stdout, short_output.stdout, "--version and -V should produce identical output");
+    let stdout = String::from_utf8_lossy(&long_output.stdout);
+    assert!(stdout.contains("diffguard"), "version should contain package name: {}", stdout);
+}

--- a/specs-010-version-flag.md
+++ b/specs-010-version-flag.md
@@ -1,0 +1,29 @@
+# Specification: `--version` Flag for DiffGuard
+
+## Feature / Behavior Description
+
+Add a `--version` (and `-V`) flag to the diffguard CLI that prints the version string from `Cargo.toml`.
+
+The version output format: `<name> <version>` where name is "diffguard" and version is `CARGO_PKG_VERSION`.
+
+## Acceptance Criteria
+
+1. `diffguard --version` prints the version string
+2. `diffguard -V` prints the version string (shorthand)
+3. Version matches `CARGO_PKG_VERSION` from `Cargo.toml`
+4. `--help` output shows the version under the CLI name
+5. Exit code is 0 when `--version` is used
+
+## Non-Goals
+
+- This does not add version to any structured output formats
+- This does not add a `--version` subcommand (flag only)
+
+## Dependencies
+
+- None (clap 4.x built-in feature, `CARGO_PKG_VERSION` is compile-time constant)
+
+## Test Plan
+
+1. CLI integration test: `diffguard --version` produces output containing the version
+2. CLI integration test: `diffguard -V` produces output containing the version

--- a/tasks-010-version-flag.md
+++ b/tasks-010-version-flag.md
@@ -1,0 +1,13 @@
+# Task List: work-3b090538 — `--version` Flag
+
+## Implementation Tasks
+
+1. Task 1: Add `#[command(version)]` to `Cli` struct
+   - Add the attribute above `#[derive(Parser)]` on the `Cli` struct
+   - Input: `crates/diffguard/src/main.rs`
+   - Output: Modified `Cli` struct
+
+2. Task 2: Run CI verification
+   - `cargo fmt && cargo clippy --all-targets && cargo test --workspace`
+   - Input: Full workspace
+   - Output: Passing CI pipeline


### PR DESCRIPTION
Adds #[command(version)] to Cli struct. Clap 4.x automatically derives --version/-V from CARGO_PKG_VERSION.

Closes #47

Work item: work-3b090538