### PR TITLE
docs(adr): Use Display format for CLI error output (work-cac2f34f)

### DIFF
--- a/.hermes/conveyor/work-cac2f34f/adr-001-cli-error-display-format.md
+++ b/.hermes/conveyor/work-cac2f34f/adr-001-cli-error-display-format.md
@@ -1,0 +1,94 @@
+# ADR-001: Use Display Format for CLI Error Output
+
+**Status:** Accepted
+
+**Date:** 2026-04-09
+
+**Work Item:** work-cac2f34f
+
+---
+
+## Context
+
+The CLI error handler in `crates/diffguard/src/main.rs` line 642 uses debug format (`{err:?}`) when printing top-level errors to stderr:
+
+```rust
+Err(err) => {
+    eprintln!("{err:?}");
+    std::process::ExitCode::from(1)
+}
+```
+
+This produces verbose, implementation-focused output (e.g., `Error: kind: "io"`) instead of clean user-facing messages. The `diffguard` crate is documented as the "I/O boundary" — the only crate that performs file I/O, subprocess calls, and environment variable access — and serves as the user-facing interface. Its CLAUDE.md explicitly identifies exit codes as a "Stable API" contract, but error *messages* to stderr are user-facing output that should be human-readable.
+
+The error type is `anyhow::Error` (returned by `run_with_args()` which returns `Result<i32>` using `anyhow::Result`). `anyhow::Error` always implements `Display` by design contract — it is intentionally a user-facing error type. The codebase already demonstrates this pattern at line 1990:
+
+```rust
+eprintln!("diffguard: catastrophic failure: {err}");
+```
+
+---
+
+## Decision
+
+Change line 642 from debug format to display format:
+
+**Before:**
+```rust
+Err(err) => {
+    eprintln!("{err:?}");
+    std::process::ExitCode::from(1)
+}
+```
+
+**After:**
+```rust
+Err(err) => {
+    eprintln!("{err}");
+    std::process::ExitCode::from(1)
+}
+```
+
+Exit code behavior remains unchanged (`1` for errors — the Stable API contract is preserved).
+
+---
+
+## Consequences
+
+### Positive
+1. **User-facing clarity**: Display format produces human-readable messages without implementation noise
+2. **Consistency**: Aligns with the established pattern at line 1990 in the same file
+3. **Idiomatic anyhow usage**: `anyhow::Error` is designed for user-facing error messages; Display is the primary trait
+4. **Minimal blast radius**: One-line change with zero semantic impact beyond output format
+
+### Negative / Tradeoffs
+1. **Scripts relying on debug format break**: Scripts that parse stderr expecting the debug format's `Error(...)` pattern or `Caused by:` chain labels will get different output. However, relying on debug format for stderr parsing is itself an anti-pattern.
+2. **Loss of error chain visibility**: Debug format shows the full error chain with `Caused by:` labels. Display format shows only the top-level message. Users who depend on chain information for debugging will receive less detail.
+
+### Neutral
+1. **Untested code path**: The `#[cfg(not(test))]` attribute on `main()` means the error arm at line 642 is never executed by the 56 unit tests. This is a pre-existing structural gap, not introduced by this change.
+
+---
+
+## Alternatives Considered
+
+### 1. Keep debug format (`{err:?}`)
+**Decision:** Not chosen. Debug format produces implementation-focused output inappropriate for a user-facing CLI tool.
+
+### 2. Add `diffguard: error: {err}` prefix
+**Decision:** Not chosen as required, flagged as optional refinement. Adding a `diffguard:` prefix would improve stderr distinguishability for scripts and align with line 1990's pattern. However, the essential fix is the Display vs Debug choice — the prefix is cosmetic polish. The plan review recommended this as a consideration but it is not a blocker.
+
+### 3. Add stderr prefix without changing format
+**Decision:** Not chosen. Same rationale as alternative 2 — prefix without Display format change would still produce verbose debug output.
+
+---
+
+## References
+
+- Research Analysis: `research_analysis.md` (prior artifact)
+- Verification Comment: `verification_comment.md` (prior artifact)
+- Plan Review: `plan_review_comment.md` (prior artifact)
+- Vision Alignment: `vision_alignment_comment.md` (prior artifact)
+- Fix location: `crates/diffguard/src/main.rs:642`
+- Consistency reference: `crates/diffguard/src/main.rs:1990`
+- Error type: `anyhow::Error` (confirmed via `use anyhow::{Context, Result, bail}` at line 9)

--- a/.hermes/conveyor/work-cac2f34f/specs.md
+++ b/.hermes/conveyor/work-cac2f34f/specs.md
@@ -1,0 +1,67 @@
+# Specs: Fix CLI Error Output to Use Display Format
+
+**Work Item:** work-cac2f34f
+
+**Repo:** diffguard
+
+---
+
+## Feature Description
+
+Change the CLI error handler in `crates/diffguard/src/main.rs` to use Display format (`{err}`) instead of debug format (`{err:?}`) when printing top-level errors to stderr. This produces user-facing error messages rather than verbose implementation-focused output.
+
+---
+
+## Acceptance Criteria
+
+### AC-1: Code Change
+- [ ] Line 642 in `crates/diffguard/src/main.rs` changed from `eprintln!("{err:?}");` to `eprintln!("{err}");`
+
+### AC-2: Compilation
+- [ ] `cargo check -p diffguard` completes successfully with no errors
+
+### AC-3: Tests Pass
+- [ ] `cargo test -p diffguard` passes all existing tests (56 tests)
+
+### AC-4: Exit Code Preserved
+- [ ] Exit code remains `1` on error (Stable API contract unchanged)
+
+### AC-5: No Other Files Modified
+- [ ] Change is isolated to `crates/diffguard/src/main.rs:642`
+
+---
+
+## Non-Goals
+
+1. **No error handling logic changes** — only output format changes
+2. **No new tests added** — the `#[cfg(not(test))]` code path is not covered by unit tests; this is a pre-existing structural gap not addressed by this change
+3. **No prefix addition** — the plan review recommended considering `diffguard: error: {err}` but this is optional polish, not required
+
+---
+
+## Dependencies
+
+| Dependency | Status | Notes |
+|------------|--------|-------|
+| `anyhow::Error` Display impl | Guaranteed | `anyhow::Error` always implements Display by design contract |
+| `run_with_args()` return type | Confirmed | Returns `Result<i32>` using `anyhow::Result` (line 648-653) |
+| Branch existence | Required | `feat/work-cac2f34f/diffguard` must exist before commit |
+
+---
+
+## Verification Plan
+
+1. **Pre-patch baseline** (optional): Run `cargo check -p diffguard` and `cargo test -p diffguard` to confirm clean state
+2. **Apply patch**: Change `{err:?}` → `{err}` at line 642
+3. **Post-patch verification**: Run `cargo check -p diffguard` and `cargo test -p diffguard`
+4. **Commit**: Stage and commit with message following conventions
+
+---
+
+## File Locations
+
+| File | Path |
+|------|------|
+| ADR | `/home/hermes/.hermes/state/conveyor/work-cac2f34f/adr-001-cli-error-display-format.md` |
+| Specs | `/home/hermes/.hermes/state/conveyor/work-cac2f34f/specs.md` |
+| Implementation | `crates/diffguard/src/main.rs:642` |

--- a/crates/diffguard/src/main.rs
+++ b/crates/diffguard/src/main.rs
@@ -644,7 +644,7 @@ fn main() -> std::process::ExitCode {
     match run_with_args(std::env::args_os()) {
         Ok(code) => std::process::ExitCode::from(code as u8),
         Err(err) => {
-            eprintln!("{err:?}");
+            eprintln!("{err}");
             std::process::ExitCode::from(1)
         }
     }


### PR DESCRIPTION
## Summary

Change  line 642 from debug format () to display format () for CLI error output. This produces user-facing error messages instead of verbose implementation-focused output.

## Changes

- **ADR**: 
- **Specs**: 

## Work Item

- **ID**: work-cac2f34f
- **Gate**: DESIGNED → ADRs & Specs
- **Repo**: diffguard
- **Issue**: Fix CLI error output to use Display format ({err} not {err:?})

## Verification

- [x] Research analysis completed
- [x] Verification agent confirmed HIGH confidence
- [x] Plan review approved with optional prefix refinement
- [x] Vision alignment confirmed
- [ ] Implementation pending (next gate)