### PR TITLE
fix(xml): escape_xml handle control characters (0x00-0x1F)

### DIFF
--- a/.hermes/conveyor/work-93f8df2f/adr.md
+++ b/.hermes/conveyor/work-93f8df2f/adr.md
@@ -1,0 +1,114 @@
+# ADR-013: Fix `escape_xml` to Handle XML Control Characters (0x00–0x1F)
+
+**Status:** Proposed
+
+**Date:** 2026-04-10
+
+**Work Item:** work-93f8df2f
+
+---
+
+## Context
+
+The `escape_xml` function used in JUnit and Checkstyle XML output renderers does not escape XML control characters in the range U+0000–U+001F. According to the XML 1.0 specification (W3C REC-xml), these characters are illegal in XML documents and must be either:
+- Removed, or
+- Escaped as character references (e.g., `&#x0;`)
+
+The current implementation only handles the five named XML special characters (`&`, `<`, `>`, `"`, `'`) but omits the mandatory escaping of control characters. This produces invalid XML when control characters appear in any text field (e.g., `Finding.message`, `Finding.path`, `Finding.rule_id`).
+
+The issue affects two identical `escape_xml` implementations:
+- `crates/diffguard-core/src/junit.rs` — lines 107–120
+- `crates/diffguard-core/src/checkstyle.rs` — lines 83–96
+
+---
+
+## Decision
+
+Add control character escaping to the `escape_xml` function match expression in both `junit.rs` and `checkstyle.rs`. Characters in the range U+0000–U+001F, except tab (U+0009), line feed (U+000A), and carriage return (U+000D) which are legal in XML 1.0, will be escaped as XML hex character references (`&#xNN;`).
+
+**Implementation:**
+
+```rust
+fn escape_xml(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            // Escape control characters (0x00–0x1F) except tab, LF, CR
+            c if c <= '\u{001F}' && c != '\t' && c != '\n' && c != '\r' => {
+                out.push_str(&format!("&#x{:X};", c as u32));
+            }
+            _ => out.push(c),
+        }
+    }
+    out
+}
+```
+
+**Key points:**
+- Uses the XML hex character reference format (`&#xNN;`) which is valid for all control characters
+- Explicitly excludes tab/LF/CR because those ARE legal in XML 1.0
+- Reuses the existing match-based structure, keeping code style consistent
+- The `format!` call is only triggered for rare control character inputs, so performance impact is negligible
+
+---
+
+## Alternatives Considered
+
+### 1. Use a regex-based approach
+Replace the char-by-char match with a `regex::Regex` substitution (e.g., `regex::Regex::new(r"[\x{00}-\x{08}\x{0B}\x{0C}\x{0E}-\x{1F}]").unwrap()`).
+
+**Tradeoff:** Adds a regex dependency and is slower for small strings. The match-based approach is more explicit and has zero allocation for non-control-character inputs.
+
+### 2. Add explicit match arms for each control character
+List all 28 illegal control characters (0x00–0x08, 0x0B, 0x0C, 0x0E–0x1F) as individual match arms.
+
+**Tradeoff:** Verbose and error-prone to maintain. The guard condition approach is cleaner and more maintainable.
+
+### 3. Extract shared utility to a common module
+Create a shared `escape_xml` utility in a common module and import it in both `junit.rs` and `checkstyle.rs`.
+
+**Tradeoff:** While this eliminates duplication, it requires restructuring module dependencies. The duplication is a known issue tracked separately. This fix should be minimal and focused.
+
+### 4. Use an external XML crate (e.g., `quick-xml`, `xml-rs`)
+Replace the manual string building with a proper XML library.
+
+**Tradeoff:** Significant scope creep. The manual approach works correctly for this use case; adding a full XML library is disproportionate to the fix needed.
+
+---
+
+## Consequences
+
+**Positive:**
+- JUnit and Checkstyle XML output will be valid according to XML 1.0 specification
+- CI systems (GitHub Actions, GitLab CI, Jenkins) that parse these XML formats will no longer receive invalid documents
+- The fix is defensive — it handles edge cases even if diffguard's own processing rarely produces control characters
+
+**Negative:**
+- Both `junit.rs` and `checkstyle.rs` must be updated in the same commit to maintain consistency
+- Snapshot tests (`insta`) may need review and acceptance if test output changes
+- Slight performance overhead from `format!` call when control characters are present (negligible in practice)
+
+**Neutral:**
+- No changes to the public API or CLI interface
+- No new dependencies required
+
+---
+
+## Risk Assessment
+
+- **Invalid XML output (MEDIUM):** Currently, if any control character appears in a text field, the resulting XML is malformed. The fix ensures valid XML is always produced.
+- **Inconsistent fixes (LOW):** Both files must be updated together. Mitigated by updating both files in the same commit.
+- **Snapshot test churn (LOW):** New snapshots may need acceptance. Normal for snapshot testing workflows.
+- **Performance regression (VERY LOW):** The `format!` call is only made for control characters, which are rare in practice.
+
+---
+
+## Files Affected
+
+- `crates/diffguard-core/src/junit.rs` — add control character escaping to `escape_xml`
+- `crates/diffguard-core/src/checkstyle.rs` — add control character escaping to `escape_xml`

--- a/.hermes/conveyor/work-93f8df2f/specs.md
+++ b/.hermes/conveyor/work-93f8df2f/specs.md
@@ -1,0 +1,55 @@
+# Specification: XML `escape_xml` Control Character Fix
+
+## Feature / Behavior Description
+
+Fix the `escape_xml` function in JUnit and Checkstyle XML output renderers to properly escape XML control characters (U+0000–U+001F) according to the XML 1.0 specification.
+
+**Problem:** The current `escape_xml` implementation only escapes the five named XML special characters (`&`, `<`, `>`, `"`, `'`) but does not escape control characters in the range 0x00–0x1F. These characters are illegal in XML 1.0 documents (except tab U+0009, line feed U+000A, and carriage return U+000D which are permitted).
+
+**Solution:** Add a guard condition in the match expression that escapes any control character in range U+0000–U+001F (excluding tab, LF, CR) as an XML hex character reference (`&#xNN;`).
+
+**Examples:**
+- `\0` (U+0000) → `&#x0;`
+- `\x01` (U+0001) → `&#x1;`
+- `\x1F` (U+001F) → `&#x1F;`
+- Tab, LF, CR are NOT escaped (they are legal in XML 1.0)
+
+## Acceptance Criteria
+
+1. **`escape_xml` escapes all illegal control characters (0x00–0x08, 0x0B, 0x0C, 0x0E–0x1F)** — For each illegal control character, the output contains the hex character reference (e.g., `&#x0;` for null, `&#x1F;` for unit separator).
+
+2. **`escape_xml` does NOT escape tab, LF, or CR** — These three legal XML characters pass through unchanged.
+
+3. **`escape_xml` continues to escape the five named XML entities** — `&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`, `"` → `&quot;`, `'` → `&apos;`.
+
+4. **Both `junit.rs` and `checkstyle.rs` implementations are fixed** — The identical `escape_xml` function in both files produces the same correct behavior.
+
+5. **XML output with control characters is parseable** — JUnit and Checkstyle XML output containing previously-unescaped control characters can be parsed by standard XML parsers (e.g., `xmllint`, Python's `xml.etree`, Java's DOM parser).
+
+6. **Existing snapshot tests pass** — No regression in existing test output for inputs without control characters.
+
+7. **New unit tests cover control character escaping** — Test cases verify illegal control characters are escaped and legal ones (tab, LF, CR) are not.
+
+## Non-Goals
+
+- This does NOT extract `escape_xml` into a shared utility module (duplication is a known issue tracked separately)
+- This does NOT add an external XML library dependency
+- This does NOT change any CLI flags or user-facing behavior
+- This does NOT affect SARIF or other JSON-based output formats (JSON has different escaping rules)
+- This does NOT address Unicode characters beyond the ASCII control character range (U+0080 and above are legal in XML 1.0)
+
+## Dependencies
+
+- No new Rust dependencies required — the fix uses only standard library features (`String`, `chars()`, `format!`)
+- Rust MSRV (1.70) is unaffected — all used APIs have been stable since Rust 1.0
+
+## Test Plan
+
+1. **Unit test:** `escape_xml` with illegal control character (e.g., `\x00`, `\x01`) outputs hex character reference
+2. **Unit test:** `escape_xml` with tab (`\t`) passes through unchanged
+3. **Unit test:** `escape_xml` with LF (`\n`) passes through unchanged
+4. **Unit test:** `escape_xml` with CR (`\r`) passes through unchanged
+5. **Unit test:** `escape_xml` with mixed content (normal text + control chars + special chars) escapes correctly
+6. **Integration test:** Render JUnit XML with a finding containing a control character in the message field; verify output is valid XML
+7. **Integration test:** Render Checkstyle XML with a finding containing a control character in the message field; verify output is valid XML
+8. **Snapshot test:** `cargo insta test -p diffguard-core` passes with existing snapshots unchanged


### PR DESCRIPTION
Fixes work-93f8df2f: escape_xml doesn't handle control characters (0x00–0x1F)