### PR TITLE
fix(gitlab_quality): use match_text for stable fingerprints

### DIFF
--- a/crates/diffguard-core/src/gitlab_quality.rs
+++ b/crates/diffguard-core/src/gitlab_quality.rs
@@ -123,7 +123,7 @@ fn compute_fingerprint(finding: &Finding) -> String {
     if let Some(col) = finding.column {
         hasher.update(col.to_string().as_bytes());
     }
-    hasher.update(finding.message.as_bytes());
+    hasher.update(finding.match_text.as_bytes());
     format!("{:x}", hasher.finalize())
 }
 
@@ -193,6 +193,26 @@ mod tests {
             line,
             column: None,
             match_text: "matched".to_string(),
+            snippet: String::new(),
+        }
+    }
+
+    fn make_finding_with_match_text(
+        rule_id: &str,
+        severity: Severity,
+        message: &str,
+        path: &str,
+        line: u32,
+        match_text: &str,
+    ) -> Finding {
+        Finding {
+            rule_id: rule_id.to_string(),
+            severity,
+            message: message.to_string(),
+            path: path.to_string(),
+            line,
+            column: None,
+            match_text: match_text.to_string(),
             snippet: String::new(),
         }
     }
@@ -299,5 +319,101 @@ mod tests {
         let receipt = make_test_receipt(vec![]);
         let json = render_gitlab_quality_json(&receipt).expect("should serialize");
         insta::assert_snapshot!("gitlab_quality_no_findings", json);
+    }
+
+    // ── Fingerprint bug-fix tests ─────────────────────────────────────────────
+    // Bug: compute_fingerprint used finding.message instead of finding.match_text.
+    // These tests will FAIL until the fix is applied (line 126: use match_text).
+
+    /// Two findings with the same rule_id, path, line, and message BUT different
+    /// match_text MUST have different fingerprints. Using message in the hash
+    /// causes these to collide (same fingerprint), which is wrong.
+    #[test]
+    fn fingerprint_uses_match_text_not_message() {
+        let finding_a = make_finding_with_match_text(
+            "rust.no_unwrap",
+            Severity::Error,
+            "Avoid unwrap/expect in production code.", // same message
+            "src/main.rs",
+            42,
+            ".unwrap()", // different match_text
+        );
+        let finding_b = make_finding_with_match_text(
+            "rust.no_unwrap",
+            Severity::Error,
+            "Avoid unwrap/expect in production code.", // same message
+            "src/main.rs",
+            42,
+            ".expect(\"something\")", // different match_text
+        );
+
+        let report_a = render_gitlab_quality_for_receipt(&make_test_receipt(vec![finding_a]));
+        let report_b = render_gitlab_quality_for_receipt(&make_test_receipt(vec![finding_b]));
+
+        // The fingerprints MUST differ because match_text differs
+        assert_ne!(
+            report_a[0].fingerprint, report_b[0].fingerprint,
+            "fingerprint must use match_text, not message; \
+             findings with different match_text values should have different fingerprints"
+        );
+    }
+
+    /// Verify that match_text alone drives fingerprint differentiation when all
+    /// other fields are identical. This isolates the fix to match_text hashing.
+    #[test]
+    fn fingerprint_changes_when_match_text_changes() {
+        let base = make_finding_with_match_text(
+            "js.no_console",
+            Severity::Warn,
+            "Remove console.log before merging.",
+            "src/index.js",
+            10,
+            "console.log",
+        );
+        let changed = make_finding_with_match_text(
+            "js.no_console",
+            Severity::Warn,
+            "Remove console.log before merging.",
+            "src/index.js",
+            10,
+            "console.warn",
+        );
+
+        let report_base = render_gitlab_quality_for_receipt(&make_test_receipt(vec![base]));
+        let report_changed = render_gitlab_quality_for_receipt(&make_test_receipt(vec![changed]));
+
+        assert_ne!(
+            report_base[0].fingerprint, report_changed[0].fingerprint,
+            "changing only match_text must change the fingerprint"
+        );
+    }
+
+    /// Sanity check: two completely identical findings must produce identical fingerprints.
+    #[test]
+    fn fingerprint_identical_for_identical_findings() {
+        let finding_a = make_finding_with_match_text(
+            "rust.no_unwrap",
+            Severity::Error,
+            "Avoid unwrap.",
+            "src/lib.rs",
+            99,
+            ".unwrap()",
+        );
+        let finding_b = make_finding_with_match_text(
+            "rust.no_unwrap",
+            Severity::Error,
+            "Avoid unwrap.",
+            "src/lib.rs",
+            99,
+            ".unwrap()",
+        );
+
+        let report_a = render_gitlab_quality_for_receipt(&make_test_receipt(vec![finding_a]));
+        let report_b = render_gitlab_quality_for_receipt(&make_test_receipt(vec![finding_b]));
+
+        assert_eq!(
+            report_a[0].fingerprint, report_b[0].fingerprint,
+            "identical findings must produce identical fingerprints"
+        );
     }
 }

--- a/crates/diffguard-core/src/snapshots/diffguard_core__gitlab_quality__tests__gitlab_quality_with_findings.snap
+++ b/crates/diffguard-core/src/snapshots/diffguard_core__gitlab_quality__tests__gitlab_quality_with_findings.snap
@@ -5,7 +5,7 @@ expression: json
 [
   {
     "description": "Avoid unwrap/expect in production code.",
-    "fingerprint": "62e2d69557c0f04afc9867bf4ed5d88dc230e747dd59d03c0cb497bb4af94879",
+    "fingerprint": "e55a93bc3889c835761d9620adf098e07759a24fed4ade227eafc053877004da",
     "severity": "major",
     "location": {
       "path": "src/main.rs",
@@ -17,7 +17,7 @@ expression: json
   },
   {
     "description": "Use of console.log detected.",
-    "fingerprint": "3d9ac9a3a07bffdfe0d5c8f0731ae10d03c7860beb9e2f6c98da4c382a54ba2d",
+    "fingerprint": "bdc0e0c24e99798d4bcaeb858a3e6c094f01a5d92e74d1720a870a453e655f95",
     "severity": "minor",
     "location": {
       "path": "src/index.js",

--- a/crates/diffguard-core/tests/snapshots/test_gitlab_quality__gitlab_quality_all_severities.snap
+++ b/crates/diffguard-core/tests/snapshots/test_gitlab_quality__gitlab_quality_all_severities.snap
@@ -5,7 +5,7 @@ expression: json
 [
   {
     "description": "Info message",
-    "fingerprint": "a2419f4418f0f7cd82effa89916933df8c6672c522b8f01d18764d14fc6611fd",
+    "fingerprint": "f05a34a28ab4a6044a311bc61a7cebb8cb82a9f4dab77832cc95ae83be3bed72",
     "severity": "info",
     "location": {
       "path": "a.rs",
@@ -20,7 +20,7 @@ expression: json
   },
   {
     "description": "Warning message",
-    "fingerprint": "33fe0827323d33847a5d7309305850d7bae8311520e53e9b01c1660d1a6d3d39",
+    "fingerprint": "15afd9a18f807846c4c89d0ecc52a379816d15f3730637684868a5865deffa2a",
     "severity": "minor",
     "location": {
       "path": "b.rs",
@@ -35,7 +35,7 @@ expression: json
   },
   {
     "description": "Error message",
-    "fingerprint": "43762896ee3d741df0a4b0cba167055722078b087c703a8bfe0795d5b263b704",
+    "fingerprint": "622aad4b81d6b5838e33eba58aad3119ed4d66879fb29824282d741b801582ce",
     "severity": "major",
     "location": {
       "path": "c.rs",

--- a/crates/diffguard-core/tests/snapshots/test_gitlab_quality__gitlab_quality_single_finding.snap
+++ b/crates/diffguard-core/tests/snapshots/test_gitlab_quality__gitlab_quality_single_finding.snap
@@ -5,7 +5,7 @@ expression: json
 [
   {
     "description": "Use of console.log detected",
-    "fingerprint": "2c2974db2047a8af23dd7f769b3c0ec3d5f882fbc4dcb6832eb19b805c95f971",
+    "fingerprint": "09de548a8c9ea34302a1eafe86158637e22065b15b08d2ac3c59fec40547afa6",
     "severity": "minor",
     "location": {
       "path": "src/index.js",


### PR DESCRIPTION
## Summary
Fix `compute_fingerprint` in `gitlab_quality.rs` to use `finding.match_text` instead of `finding.message` for SHA-256 fingerprint computation.\n\n**Problem**: `message` is an unstable human-readable description that can change across CI runs (e.g., rule description updates), causing fingerprint instability. GitLab Code Quality uses fingerprints to deduplicate findings - unstable fingerprints cause the same finding to appear as multiple separate issues.\n\n**Solution**: Use `match_text` (the actual code pattern matched) instead of `message`, aligning with the established `fingerprint.rs` implementation.\n\n\n**Changes**:\n- `gitlab_quality.rs` line 126: `message` → `match_text`\n- 3 regression tests added verifying fingerprint stability\n- 3 snapshot files updated with new (correct) fingerprint values\n\n**Testing**: All `cargo test --workspace` tests pass (0 failures), `cargo fmt --check` passes, `cargo clippy` passes with 0 warnings.\n\nFixes #148