### PR TITLE
fix(clippy): redundant closures and double unwrap_or in evaluate.rs

### DIFF
--- a/crates/diffguard-domain/src/evaluate.rs
+++ b/crates/diffguard-domain/src/evaluate.rs
@@ -113,7 +113,7 @@ pub fn evaluate_lines_with_overrides_and_language(
     let mut p_both =
         Preprocessor::with_language(PreprocessOptions::comments_and_strings(), current_lang);
 
-    let forced_language_name = force_language.map(|lang| lang.to_ascii_lowercase());
+    let forced_language_name = force_language.map(str::to_ascii_lowercase);
     let forced_language_enum =
         forced_language_name
             .as_deref()
@@ -132,7 +132,7 @@ pub fn evaluate_lines_with_overrides_and_language(
             } else {
                 let path = std::path::Path::new(&input.path);
                 detect_language(path)
-                    .map(|s| s.parse::<Language>().unwrap_or(Language::Unknown))
+                    .and_then(|s| s.parse::<Language>().ok())
                     .unwrap_or(Language::Unknown)
             };
 


### PR DESCRIPTION
Closes #157

## Summary
Fix two clippy lint warnings in crates/diffguard-domain/src/evaluate.rs:
- Line 116: Replace redundant closure with str::to_ascii_lowercase method reference  
- Lines 134-136: Replace redundant double unwrap_or pattern with and_then(...ok()).unwrap_or()

## What Changed
- crates/diffguard-domain/src/evaluate.rs (2 lines changed)
- crates/diffguard-domain/tests/clippy_refactor_test.rs (new test file)

## Test Results
- cargo clippy -p diffguard-domain: clean
- cargo test -p diffguard-domain: 9+ tests passed
- No behavioral change

## Notes
- Draft PR — ready for review once green-test-builder confirms all tests pass
- Issue: #157
