### PR TITLE
chore: ignore conveyor artifact directories in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,14 @@ artifacts/
 *.pdb
 *.profraw
 .tmp_*
+# Conveyor artifacts — live in ~/.hermes/state/conveyor/, not repo
+.hermes/
+# Agent findings and plans — not part of code history
+findings/
+# Mutation testing output
+mutants.out*/
+# Vim swap files
+*.rs:*
+*~
+# Extra snapshot directories (not cargo snapshots)
+crates/diffguard/src/snapshots/


### PR DESCRIPTION
## Summary
Adds patterns to `.gitignore` to prevent conveyor artifacts from being committed to the repo:

- `.hermes/` — conveyor state and work item directories
- `findings/` — agent findings (should live in `~/.hermes/state/conveyor/<work-id>/`)
- `mutants.out*/` — mutation testing output
- `*.rs:*` — vim swap files
- `*~` — emacs swap files
- `crates/diffguard/src/snapshots/` — extra snapshot directories

These directories should live in `~/.hermes/state/conveyor/`, not in the repo. Prevents cross-work-item artifact contamination in diffs and PRs.
