### PR TITLE
fix(clippy): redundant closures across diffguard workspace

### DIFF
--- a/crates/diffguard-core/tests/property_tests_escape_xml.rs
+++ b/crates/diffguard-core/tests/property_tests_escape_xml.rs
@@ -8,16 +8,16 @@ use proptest::prelude::*;
 /// Characters that must be escaped in XML text content
 const SPECIAL_CHARS: &[char] = &['&', '<', '>', '"', '\''];
 
-/// Property 1: Length bound - output length >= input length
-///
-/// Escaping replaces single characters with multi-character sequences:
-/// - `&` → `&amp;` (5 chars)
-/// - `<` → `&lt;` (4 chars)
-/// - `>` → `&gt;` (4 chars)
-/// - `"` → `&quot;` (6 chars)
-/// - `'` → `&apos;` (6 chars)
-///
-/// Therefore, output.len() >= input.len() always holds.
+// Property 1: Length bound - output length >= input length
+//
+// Escaping replaces single characters with multi-character sequences:
+// - `&` → `&amp;` (5 chars)
+// - `<` → `&lt;` (4 chars)
+// - `>` → `&gt;` (4 chars)
+// - `"` → `&quot;` (6 chars)
+// - `'` → `&apos;` (6 chars)
+//
+// Therefore, output.len() >= input.len() always holds.
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(200))]
 
@@ -34,10 +34,10 @@ proptest! {
     }
 }
 
-/// Property 2: Special chars escaped - &,<,>,",' must never appear unescaped in output
-///
-/// After escaping, none of the special XML characters should appear unescaped
-/// in the output. They should only appear as part of their entity references.
+// Property 2: Special chars escaped - &,<,>,",' must never appear unescaped in output
+//
+// After escaping, none of the special XML characters should appear unescaped
+// in the output. They should only appear as part of their entity references.
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(200))]
 
@@ -111,7 +111,7 @@ fn empty_input_produces_empty_output() {
     assert_eq!(output, "", "Empty input should produce empty output");
 }
 
-/// Property 4: Normal text preserved - chars not in {&,<,>,",'} pass through unchanged
+// Property 4: Normal text preserved - chars not in {&,<,>,",'} pass through unchanged
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(200))]
 
@@ -160,8 +160,8 @@ fn single_quote_maps_to_apos() {
     assert_eq!(escape_xml("'"), "&apos;");
 }
 
-/// Property 6: No information loss - verify original content can be reconstructed
-/// for text without special chars
+// Property 6: No information loss - verify original content can be reconstructed
+// for text without special chars
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(200))]
 

--- a/crates/diffguard-domain/src/evaluate.rs
+++ b/crates/diffguard-domain/src/evaluate.rs
@@ -113,7 +113,7 @@ pub fn evaluate_lines_with_overrides_and_language(
     let mut p_both =
         Preprocessor::with_language(PreprocessOptions::comments_and_strings(), current_lang);
 
-    let forced_language_name = force_language.map(|lang| lang.to_ascii_lowercase());
+    let forced_language_name = force_language.map(str::to_ascii_lowercase);
     let forced_language_enum =
         forced_language_name
             .as_deref()

--- a/crates/diffguard-lsp/src/config.rs
+++ b/crates/diffguard-lsp/src/config.rs
@@ -93,7 +93,7 @@ pub fn extract_rule_id(diagnostic: &Diagnostic) -> Option<String> {
         .as_ref()
         .and_then(|value| value.get("ruleId"))
         .and_then(|value| value.as_str())
-        .map(|s| s.to_string())
+        .map(ToString::to_string)
 }
 
 pub fn find_rule<'a>(config: &'a ConfigFile, rule_id: &str) -> Option<&'a RuleConfig> {

--- a/crates/diffguard-lsp/src/server.rs
+++ b/crates/diffguard-lsp/src/server.rs
@@ -816,7 +816,7 @@ fn nth_string_arg(arguments: &[serde_json::Value], index: usize) -> Option<Strin
     arguments
         .get(index)
         .and_then(|value| value.as_str())
-        .map(|value| value.to_string())
+        .map(ToString::to_string)
 }
 
 fn send_ok_response(

--- a/crates/diffguard-testkit/src/arb.rs
+++ b/crates/diffguard-testkit/src/arb.rs
@@ -211,7 +211,7 @@ fn arb_file_extension() -> impl Strategy<Value = String> {
         "rs", "py", "js", "ts", "jsx", "tsx", "go", "java", "kt", "rb", "c", "cpp", "h", "hpp",
         "cs", "txt", "md", "json", "yaml", "toml",
     ])
-    .prop_map(|s| s.to_string())
+    .prop_map(ToString::to_string)
 }
 
 /// Strategy for generating directory names.
@@ -220,7 +220,7 @@ fn arb_dir_name() -> impl Strategy<Value = String> {
         "src", "lib", "bin", "tests", "test", "examples", "benches", "docs", "scripts", "utils",
         "core", "api", "internal", "pkg", "cmd", "app",
     ])
-    .prop_map(|s| s.to_string())
+    .prop_map(ToString::to_string)
 }
 
 /// Strategy for generating non-empty strings suitable for IDs and messages.
@@ -250,7 +250,7 @@ pub fn arb_language() -> impl Strategy<Value = String> {
         "cpp",
         "csharp",
     ])
-    .prop_map(|s| s.to_string())
+    .prop_map(ToString::to_string)
 }
 
 // =============================================================================

--- a/crates/diffguard-testkit/src/diff_builder.rs
+++ b/crates/diffguard-testkit/src/diff_builder.rs
@@ -75,7 +75,7 @@ impl DiffBuilder {
     pub fn build(self) -> String {
         self.files
             .iter()
-            .map(|f| f.build())
+            .map(FileBuilder::build)
             .collect::<Vec<_>>()
             .join("\n")
     }


### PR DESCRIPTION
Fixes 7 clippy::redundant_closure_for_method_calls warnings across diffguard-domain, diffguard-lsp, and diffguard-testkit.

Closes #158