### PR TITLE
fix(preprocess): remove redundant Language::Json match arms

### DIFF
--- a/crates/diffguard-domain/src/preprocess.rs
+++ b/crates/diffguard-domain/src/preprocess.rs
@@ -79,8 +79,7 @@ impl Language {
             Language::Php => CommentSyntax::Php,
             // YAML/TOML use # comments
             Language::Yaml | Language::Toml => CommentSyntax::Hash,
-            // JSON supports comments in jsonc/json5 dialects
-            Language::Json => CommentSyntax::CStyle,
+            // JSON supports comments in jsonc/json5 dialects (handled by wildcard)
             _ => CommentSyntax::CStyle,
         }
     }
@@ -104,10 +103,9 @@ impl Language {
             Language::Xml => StringSyntax::Xml,
             // PHP uses both single and double quotes
             Language::Php => StringSyntax::Php,
-            // YAML/TOML strings are C-style-like in this best-effort model
-            // (JSON is handled by the wildcard below since JSON uses C-style strings)
-            Language::Yaml | Language::Toml => StringSyntax::CStyle,
-            // All other languages (JSON, C, C++, Java, etc.) use C-style strings
+            // YAML/TOML/JSON strings are C-style-like in this best-effort model
+            Language::Yaml | Language::Toml | Language::Json => StringSyntax::CStyle,
+            // All other languages (C, C++, Java, etc.) use C-style strings
             _ => StringSyntax::CStyle,
         }
     }


### PR DESCRIPTION
## Summary
Remove redundant match arms for Language::Json in preprocess.rs — the wildcard arm already handles all cases not explicitly matched, so explicit Language::Json arms are dead code.

## Changes
- Removed explicit Language::Json => CommentSyntax::CStyle arm — the _ wildcard already matches Json with the same value
- Consolidated Language::Json into the Yaml/Toml arm since all three produce StringSyntax::CStyle

## Test Results
- `cargo test --workspace` — all tests pass
- `cargo clippy -p diffguard-domain` — clean
- `cargo run -p xtask -- ci` — all 14 checks pass

Closes #136