### PR TITLE
feat(diffguard-types): add #[must_use] to ConfigFile::built_in()

### DIFF
--- a/crates/diffguard-types/src/lib.rs
+++ b/crates/diffguard-types/src/lib.rs
@@ -245,6 +245,7 @@ impl ConfigFile {
     ///
     /// Rules are loaded from `rules/built_in.json` at compile time via `include_str!`.
     /// This ensures the JSON is embedded in the binary and avoids any I/O at runtime.
+    #[must_use]
     pub fn built_in() -> Self {
         serde_json::from_str(include_str!("rules/built_in.json"))
             .expect("built_in.json must be valid UTF-8 and parseable as ConfigFile JSON")

--- a/crates/diffguard-types/tests/green_edge_tests_work_0058c3c4.rs
+++ b/crates/diffguard-types/tests/green_edge_tests_work_0058c3c4.rs
@@ -1,0 +1,192 @@
+//! Green edge case tests for work-0058c3c4: Add `#[must_use]` to `ConfigFile::built_in()`
+//!
+//! These tests complement the red tests by verifying edge cases not covered by them:
+//! - Idempotency: Multiple calls return identical configs
+//! - Clone: The returned ConfigFile can be cloned
+//! - Partial use: The return value can be partially used
+//!
+//! The `#[must_use]` attribute is purely compile-time — it enables a warning if the
+//! return value is discarded, but does not change runtime behavior. These tests
+//! verify the runtime behavior is unchanged.
+
+use diffguard_types::{ConfigFile, Defaults, Severity};
+
+/// Test that calling `built_in()` twice returns identical configs.
+///
+/// This verifies idempotency: the compile-time embedded JSON is parsed
+/// identically every time, producing equivalent `ConfigFile` instances.
+#[test]
+fn built_in_idempotent_multiple_calls_identical() {
+    let cfg1 = ConfigFile::built_in();
+    let cfg2 = ConfigFile::built_in();
+    let cfg3 = ConfigFile::built_in();
+
+    assert_eq!(cfg1, cfg2, "first and second call should be identical");
+    assert_eq!(cfg2, cfg3, "second and third call should be identical");
+}
+
+/// Test that `built_in()` can be cloned.
+///
+/// The `#[must_use]` attribute should not prevent cloning the returned value.
+/// This is a common operation when passing configs to multiple consumers.
+#[test]
+fn built_in_result_can_be_cloned() {
+    let original = ConfigFile::built_in();
+    let cloned = original.clone();
+
+    assert_eq!(
+        original, cloned,
+        "cloned ConfigFile should be identical to original"
+    );
+    // Verify the clone is independent (modification doesn't affect original)
+    let mut modified = cloned.clone();
+    modified.rule.clear();
+    assert_eq!(
+        original.rule.len(),
+        36,
+        "clearing rules on modified copy should not affect original"
+    );
+}
+
+/// Test that the defaults from `built_in()` are the standard defaults.
+#[test]
+fn built_in_defaults_are_standard() {
+    let cfg = ConfigFile::built_in();
+
+    // Verify defaults match Defaults::default()
+    assert_eq!(cfg.defaults, Defaults::default());
+
+    // Verify specific default values
+    assert_eq!(cfg.defaults.base, Some("origin/main".to_string()));
+    assert_eq!(cfg.defaults.head, Some("HEAD".to_string()));
+    assert_eq!(cfg.defaults.scope, Some(diffguard_types::Scope::Added));
+    assert_eq!(cfg.defaults.fail_on, Some(diffguard_types::FailOn::Error));
+    assert_eq!(cfg.defaults.max_findings, Some(200));
+    assert_eq!(cfg.defaults.diff_context, Some(0));
+}
+
+/// Test that `built_in()` returns a config where includes is empty.
+#[test]
+fn built_in_includes_are_empty() {
+    let cfg = ConfigFile::built_in();
+    assert!(
+        cfg.includes.is_empty(),
+        "built_in() should have empty includes, got {:?}",
+        cfg.includes
+    );
+}
+
+/// Test that every rule in `built_in()` has a non-empty ID and valid severity.
+///
+/// This extends `built_in_returns_config_with_36_rules` by checking each rule.
+#[test]
+fn built_in_rules_have_valid_ids_and_severities() {
+    let cfg = ConfigFile::built_in();
+
+    for rule in &cfg.rule {
+        assert!(!rule.id.is_empty(), "rule ID should be non-empty");
+        assert!(
+            matches!(
+                rule.severity,
+                Severity::Info | Severity::Warn | Severity::Error
+            ),
+            "rule '{}' has invalid severity: {:?}",
+            rule.id,
+            rule.severity
+        );
+    }
+}
+
+/// Test that `built_in()` can be serialized to JSON and deserialized back.
+///
+/// This verifies the ConfigFile is a valid serde serializable type.
+#[test]
+fn built_in_round_trip_serialization() {
+    let original = ConfigFile::built_in();
+
+    // Serialize to JSON string
+    let json =
+        serde_json::to_string(&original).expect("ConfigFile::built_in() should serialize to JSON");
+
+    // Deserialize back
+    let deserialized: ConfigFile =
+        serde_json::from_str(&json).expect("ConfigFile JSON should be deserializable");
+
+    assert_eq!(original, deserialized);
+}
+
+/// Test that `built_in()` result can be partially used without warning.
+///
+/// When only some fields of the returned value are used, #[must_use] should
+/// still not warn because the value IS being used (just not completely).
+#[test]
+fn built_in_partial_use_is_valid() {
+    let cfg = ConfigFile::built_in();
+
+    // Using only the rule count - this should NOT trigger #[must_use] warning
+    // because the value IS being used (the compiler only warns when the
+    // return value is completely discarded, e.g., `ConfigFile::built_in();`)
+    let _rule_count = cfg.rule.len();
+
+    // Using only the defaults
+    let _defaults = cfg.defaults;
+
+    // Using only the includes
+    let _includes = cfg.includes;
+}
+
+/// Test that `built_in()` is Send + Sync (required for concurrent use).
+///
+/// This verifies the returned ConfigFile can be used in multithreaded contexts.
+#[test]
+fn built_in_result_is_send_and_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<ConfigFile>();
+
+    // Also verify the actual built_in() result is Send + Sync
+    let cfg = ConfigFile::built_in();
+    assert_send_sync::<ConfigFile>();
+    // Silence unused warning by using cfg
+    let _ = cfg;
+}
+
+/// Test that the `#[must_use]` count is still correct after refactoring.
+///
+/// This is a sanity check that no other `#[must_use]` attributes were added
+/// or removed accidentally.
+#[test]
+fn must_use_count_remains_four() {
+    let source = include_str!("../src/lib.rs");
+    let count = source.matches("#[must_use]").count();
+
+    assert_eq!(
+        count, 4,
+        "Expected exactly 4 #[must_use] attributes (3 as_str + 1 built_in)"
+    );
+}
+
+/// Test that `Severity::as_str` and `ConfigFile::built_in` both have `#[must_use]`.
+///
+/// This verifies the consistency of the `#[must_use]` pattern across different
+/// return types (`&'static str` vs `Self`).
+#[test]
+fn must_use_attribute_consistency() {
+    let source = include_str!("../src/lib.rs");
+
+    // Find lines with #[must_use]
+    let must_use_lines: Vec<usize> = source
+        .lines()
+        .enumerate()
+        .filter(|(_, l)| l.contains("#[must_use]"))
+        .map(|(i, _)| i + 1) // 1-indexed
+        .collect();
+
+    // Should have 4 occurrences at expected line numbers
+    assert_eq!(must_use_lines.len(), 4);
+
+    // The #[must_use] should appear above Severity::as_str, Scope::as_str,
+    // FailOn::as_str, and ConfigFile::built_in()
+    // We verify by checking these function definitions exist nearby
+    assert!(source.contains("#[must_use]\n    pub fn as_str(self) -> &'static str"));
+    assert!(source.contains("#[must_use]\n    pub fn built_in() -> Self"));
+}

--- a/crates/diffguard-types/tests/red_tests_work_0058c3c4.rs
+++ b/crates/diffguard-types/tests/red_tests_work_0058c3c4.rs
@@ -1,0 +1,111 @@
+//! Red tests for work-0058c3c4: Add `#[must_use]` to `ConfigFile::built_in()`
+//!
+//! These tests verify that `ConfigFile::built_in()` has the `#[must_use]` attribute,
+//! consistent with the existing pattern on `Severity::as_str`, `Scope::as_str`, and
+//! `FailOn::as_str` methods.
+//!
+//! **Before fix**: `ConfigFile::built_in()` at line 248 lacks `#[must_use]`
+//! **After fix**: `#[must_use]` present on line directly above `pub fn built_in()`
+
+/// Test that `ConfigFile::built_in()` has `#[must_use]` attribute directly above it.
+///
+/// The `#[must_use]` attribute signals that the return value carries semantic
+/// significance and should not be silently discarded. This test verifies the
+/// attribute is present by checking the line immediately preceding `pub fn built_in()`.
+///
+/// This test will FAIL before the fix (when the attribute is missing) and
+/// PASS after code-builder adds `#[must_use]` above `pub fn built_in()`.
+#[test]
+fn config_file_built_in_has_must_use_attribute() {
+    // Read the source file at compile time via include_str!
+    let source = include_str!("../src/lib.rs");
+
+    // Split into lines and find the line containing "pub fn built_in()"
+    let lines: Vec<&str> = source.lines().collect();
+
+    // Find the line index of "pub fn built_in()" within the ConfigFile impl block
+    let impl_block_start = lines
+        .iter()
+        .position(|l| l.contains("impl ConfigFile {"))
+        .expect("impl ConfigFile { not found in source");
+
+    let fn_line_idx = lines[impl_block_start..]
+        .iter()
+        .position(|l| l.contains("pub fn built_in()"))
+        .expect("pub fn built_in() not found in impl ConfigFile block");
+
+    // Convert to absolute index
+    let fn_line_abs = impl_block_start + fn_line_idx;
+
+    // The line immediately before should be #[must_use] (allowing for blank lines)
+    // We search backwards from fn_line_idx to find the first non-empty line
+    let mut check_idx = fn_line_abs - 1;
+    while check_idx > impl_block_start {
+        let line = lines[check_idx].trim();
+        if line.is_empty() {
+            check_idx -= 1;
+            continue;
+        }
+        if line == "#[must_use]" {
+            // Found it! The attribute is on the line directly above (modulo blank lines)
+            return;
+        }
+        // Found something other than #[must_use] - fail
+        break;
+    }
+
+    // If we get here, #[must_use] was not found on the line above pub fn built_in()
+    panic!(
+        "\
+#[must_use] attribute is MISSING above 'pub fn built_in()'.
+
+Expected: the line(s) directly above 'pub fn built_in()' should contain '#[must_use]'
+
+The fix: add '#[must_use]' on the line directly above 'pub fn built_in()' in \
+'crates/diffguard-types/src/lib.rs', matching the pattern used by \
+Severity::as_str (line 52), Scope::as_str (line 72), and FailOn::as_str (line 92)."
+    );
+}
+
+/// Test that there are exactly 4 `#[must_use]` attributes in lib.rs.
+///
+/// Three are already present (lines 52, 72, 92 for as_str methods).
+/// After the fix, a fourth should appear above ConfigFile::built_in().
+#[test]
+fn must_use_attribute_count_is_four() {
+    let source = include_str!("../src/lib.rs");
+
+    let count = source.matches("#[must_use]").count();
+
+    assert_eq!(
+        count, 4,
+        "Expected exactly 4 #[must_use] attributes in lib.rs \
+         (lines 52, 72, 92 for as_str methods + line 248 for built_in()), \
+         but found {}. \
+         After adding #[must_use] above ConfigFile::built_in(), this count \
+         should become 4.",
+        count
+    );
+}
+
+/// Test that `ConfigFile::built_in()` return value is semantically meaningful.
+///
+/// This test documents the expected behavior: the built_in() method returns
+/// a complete ConfigFile with 36 rules loaded from embedded JSON.
+/// Discarding this value silently would be a bug, which is why
+/// `#[must_use]` is needed.
+#[test]
+fn built_in_returns_config_with_36_rules() {
+    use diffguard_types::ConfigFile;
+
+    // This line exercises ConfigFile::built_in() - the return value IS used
+    // (assigned to cfg), so even with #[must_use] there is no warning.
+    let cfg = ConfigFile::built_in();
+
+    assert_eq!(
+        cfg.rule.len(),
+        36,
+        "ConfigFile::built_in() should return exactly 36 rules, got {}",
+        cfg.rule.len()
+    );
+}

--- a/crates/diffguard/src/main.rs
+++ b/crates/diffguard/src/main.rs
@@ -2867,9 +2867,8 @@ fn cmd_test(args: TestArgs) -> Result<i32> {
     if rules.is_empty() {
         if let Some(filter) = &args.rule {
             bail!("No rules match filter '{}'", filter);
-        } else {
-            bail!("No rules defined in configuration");
         }
+        bail!("No rules defined in configuration");
     }
 
     // Count total test cases


### PR DESCRIPTION
Adds #[must_use] to ConfigFile::built_in() for consistency with as_str methods.