### PR TITLE
fix(xml_utils): use write!() macro instead of push_str+format for control char escaping (closes #321)

### DIFF
--- a/crates/diffguard-core/src/xml_utils.rs
+++ b/crates/diffguard-core/src/xml_utils.rs
@@ -3,6 +3,8 @@
 //! Provides shared XML escaping functionality used by JUnit, Checkstyle,
 //! and other XML-based output formats.
 
+use std::fmt::Write;
+
 /// Escapes special XML characters and illegal control characters in a string.
 ///
 /// Handles:
@@ -22,7 +24,7 @@ pub fn escape_xml(s: &str) -> String {
             '\'' => out.push_str("&apos;"),
             // Illegal XML control characters (0x00-0x1F except tab/LF/CR)
             c if c <= '\u{001F}' && c != '\t' && c != '\n' && c != '\r' => {
-                out.push_str(&format!("&#x{:X};", c as u32));
+                write!(out, "&#x{:X};", c as u32).unwrap();
             }
             _ => out.push(c),
         }


### PR DESCRIPTION
## Summary

Replaces `push_str(&format!(...))` with `write!(...).unwrap()` in `xml_utils.rs` line 25, eliminating an intermediate String allocation when escaping XML control characters.

## Change

```rust
// Before
out.push_str(&format!(