### PR TITLE
fix(preprocess): remove stale comment referencing non-existent Language::Json arm (closes #229)

### DIFF
--- a/crates/diffguard-domain/src/preprocess.rs
+++ b/crates/diffguard-domain/src/preprocess.rs
@@ -79,7 +79,6 @@ impl Language {
             Language::Php => CommentSyntax::Php,
             // YAML/TOML use # comments
             Language::Yaml | Language::Toml => CommentSyntax::Hash,
-            // JSON supports comments in jsonc/json5 dialects (handled by wildcard)
             _ => CommentSyntax::CStyle,
         }
     }


### PR DESCRIPTION
Closes #229