### PR TITLE
fix(main.rs): add braces to multi-line match arm to satisfy rustfmt

### DIFF
--- a/crates/diffguard/src/main.rs
+++ b/crates/diffguard/src/main.rs
@@ -642,7 +642,9 @@ impl LanguageArg {
 #[cfg(not(test))]
 fn main() -> std::process::ExitCode {
     match run_with_args(std::env::args_os()) {
-        Ok(code) => std::process::ExitCode::from(code.clamp(i32::from(u8::MIN), i32::from(u8::MAX)) as u8),
+        Ok(code) => {
+            std::process::ExitCode::from(code.clamp(i32::from(u8::MIN), i32::from(u8::MAX)) as u8)
+        }
         Err(err) => {
             eprintln!("{err:?}");
             std::process::ExitCode::from(1)


### PR DESCRIPTION
rustfmt 1.8.0 requires braces when match arm body spans multiple lines. This was causing CI failures on all PRs that merge with main.