### PR TITLE
chore: add bool to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ mutants.out*/
 *~
 # Extra snapshot directories (not cargo snapshots)
 crates/diffguard/src/snapshots/
+
+# Debug/test artifacts
+bool


### PR DESCRIPTION
Fixes #508 (and closes duplicate #507). Adds  to  to prevent debug artifact commits.