### PR TITLE
fix: correct misleading 'tool error' message on check fail paths

### DIFF
--- a/crates/diffguard/src/main.rs
+++ b/crates/diffguard/src/main.rs
@@ -1990,7 +1990,7 @@ fn cmd_check(mut args: CheckArgs) -> Result<i32> {
                                     build_tool_error_sensor_report(&args, &detail, &ctx);
                                 if let Ok(json) = serialize_sensor_report_checked(&sensor_report) {
                                     if write_text(sensor_path, &json).is_ok() {
-                                        eprintln!("diffguard: tool error: {detail}");
+                                        eprintln!("diffguard: check failed: {detail}");
                                         return Ok(0);
                                     }
                                 }
@@ -1998,7 +1998,7 @@ fn cmd_check(mut args: CheckArgs) -> Result<i32> {
 
                             // Also write the regular receipt
                             if write_json(&out_path, &fail_receipt).is_ok() {
-                                eprintln!("diffguard: tool error: {detail}");
+                                eprintln!("diffguard: check failed: {detail}");
                                 return Ok(0);
                             }
                         }


### PR DESCRIPTION
In `cmd_check` cockpit mode, the success-return paths at lines 1993 and 2001 print `diffguard: tool error` even though no tool error occurred — the receipt was written successfully and `Ok(0)` is returned.

This is actively misleading: users see 'tool error' when the only thing that happened was a check verdict of 'fail'.

Fix: replace 'tool error' with 'check failed' on those two lines. 'tool error' is reserved for the catastrophic-failure fallback (line 2006).

Closes #510.