### PR TITLE
fix(diffguard-lsp): use clone_from() instead of redundant clone()

### DIFF
--- a/crates/diffguard-lsp/src/server.rs
+++ b/crates/diffguard-lsp/src/server.rs
@@ -74,7 +74,7 @@ impl DocumentState {
         }
 
         if let Some(full_change) = changes.iter().rev().find(|change| change.range.is_none()) {
-            self.text = full_change.text.clone();
+            self.text.clone_from(&full_change.text);
             self.changed_lines = changed_lines_between(&self.baseline_text, &self.text);
             return Ok(());
         }


### PR DESCRIPTION
## Summary

Replace `self.text = full_change.text.clone()` with `self.text.clone_from(&full_change.text)` in `DocumentState::apply_changes()`.

When `self.text` already holds a value, `clone_from()` reuses the existing buffer capacity instead of deallocating and reallocating. This eliminates one heap allocation per full-document sync.

## Closes

Closes #320