### PR TITLE
fix(xtask): use map_or_else instead of map+unwrap_or_else

### DIFF
--- a/xtask/src/conform_real.rs
+++ b/xtask/src/conform_real.rs
@@ -684,15 +684,17 @@ fn test_schema_drift() -> Result<()> {
             .zip(contract_canonical.lines())
             .enumerate()
             .find(|(_, (a, b))| a != b)
-            .map(|(i, (a, b))| {
-                format!(
-                    "first divergence at line {}:\n  generated: {}\n  contract:  {}",
-                    i + 1,
-                    a,
-                    b
-                )
-            })
-            .unwrap_or_else(|| "files differ in length".to_string());
+            .map_or_else(
+                || "files differ in length".to_string(),
+                |(i, (a, b))| {
+                    format!(
+                        "first divergence at line {}:\n  generated: {}\n  contract:  {}",
+                        i + 1,
+                        a,
+                        b
+                    )
+                },
+            );
 
         bail!(
             "schema drift detected!\n\


### PR DESCRIPTION
## Summary

Replace `.map(...).unwrap_or_else(|| ...)` with `.map_or_else(|| ..., ...)` at `xtask/src/conform_real.rs:682`.

`map_or_else` performs a single Option visit instead of two, making the intent clearer and avoiding an unnecessary closure wrapper.

## Closes

Closes #488