### PR TITLE
fix: clippy cleanup — items_after_statements + unnecessary_wrap

### DIFF
--- a/crates/diffguard-domain/src/evaluate.rs
+++ b/crates/diffguard-domain/src/evaluate.rs
@@ -559,8 +559,8 @@ fn bump_counts(counts: &mut VerdictCounts, severity: Severity) {
 }
 
 fn trim_snippet(s: &str) -> String {
-    let trimmed = s.trim_end();
     const MAX_CHARS: usize = 240;
+    let trimmed = s.trim_end();
 
     // Avoid slicing by byte indices (which can panic on Unicode boundaries).
     let mut out = String::new();

--- a/crates/diffguard-lsp/src/server.rs
+++ b/crates/diffguard-lsp/src/server.rs
@@ -910,15 +910,15 @@ fn git_diff_for_path(workspace_root: &Path, relative_path: &str) -> Result<Strin
 }
 
 fn run_git_diff(workspace_root: &Path, relative_path: &str, staged: bool) -> Result<String> {
+    // Spawn with a 10-second timeout to avoid blocking the LSP indefinitely
+    const GIT_DIFF_TIMEOUT: Duration = Duration::from_secs(10);
+
     let mut command = Command::new("git");
     command.current_dir(workspace_root).arg("diff");
     if staged {
         command.arg("--cached");
     }
     command.arg("--unified=0").arg("--").arg(relative_path);
-
-    // Spawn with a 10-second timeout to avoid blocking the LSP indefinitely
-    const GIT_DIFF_TIMEOUT: Duration = Duration::from_secs(10);
     let mut child = command.spawn().context("spawn git diff")?;
     let deadline = Instant::now() + GIT_DIFF_TIMEOUT;
 

--- a/xtask/src/conform_real.rs
+++ b/xtask/src/conform_real.rs
@@ -114,16 +114,9 @@ pub fn run_conformance(quick: bool) -> Result<()> {
 
     // Test 8: Vocabulary constants
     print!("  [8/15] Vocabulary constants... ");
-    match test_vocabulary_constants() {
-        Ok(()) => {
-            println!("PASS");
-            passed += 1;
-        }
-        Err(e) => {
-            println!("FAIL: {e}");
-            failed += 1;
-        }
-    }
+    test_vocabulary_constants();
+    println!("PASS");
+    passed += 1;
 
     // Test 9: Tool error code in sensor report
     print!("  [9/15] Tool error code field... ");
@@ -717,7 +710,7 @@ fn canonicalize_json(value: &serde_json::Value) -> String {
 }
 
 /// Test that frozen vocabulary constants have the expected values.
-fn test_vocabulary_constants() -> Result<()> {
+fn test_vocabulary_constants() {
     use diffguard_types::{
         CAP_GIT, CAP_STATUS_AVAILABLE, CAP_STATUS_SKIPPED, CAP_STATUS_UNAVAILABLE,
         CHECK_ID_INTERNAL, CHECK_ID_PATTERN, CHECK_SCHEMA_V1, CODE_TOOL_RUNTIME_ERROR,
@@ -751,7 +744,6 @@ fn test_vocabulary_constants() -> Result<()> {
     assert_eq!(CAP_STATUS_UNAVAILABLE, "unavailable");
     assert_eq!(CAP_STATUS_SKIPPED, "skipped");
 
-    Ok(())
 }
 
 /// Test that cockpit-mode tool errors produce the correct code field.


### PR DESCRIPTION
## Summary

Three mechanical clippy fixes:

1. **#502** : Move `const MAX_CHARS` before the `trim_end()` call in `trim_snippet()`. Fixes `clippy::items_after_statements`.

2. **#503** `diffguard-lsp/src/server.rs:921`: Move `const GIT_DIFF_TIMEOUT` before `Command::new("git")` in `run_git_diff()`. Fixes `clippy::items_after_statements`.

3. **#504** `xtask/src/conform_real.rs:718`: Change `test_vocabulary_constants()` from `Result<()>` to `()`. Remove `Ok(())` return and update caller. Fixes `clippy::unnecessary_wrap`.

`cargo clippy --workspace` → 0 warnings. Closes #502, #503, #504