### PR TITLE
fix(diffguard-lsp): add #[must_use] to find_rule (issue #519)

### DIFF
--- a/crates/diffguard-lsp/src/config.rs
+++ b/crates/diffguard-lsp/src/config.rs
@@ -96,6 +96,7 @@ pub fn extract_rule_id(diagnostic: &Diagnostic) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+#[must_use]
 pub fn find_rule<'a>(config: &'a ConfigFile, rule_id: &str) -> Option<&'a RuleConfig> {
     config.rule.iter().find(|rule| rule.id == rule_id)
 }


### PR DESCRIPTION
Adds #[must_use] to find_rule().

Fixes #519