### PR TITLE
fix: add #[must_use] to resolve(), suppresses(), builder structs

### DIFF
--- a/crates/diffguard-domain/src/overrides.rs
+++ b/crates/diffguard-domain/src/overrides.rs
@@ -105,6 +105,7 @@ impl RuleOverrideMatcher {
     }
 
     /// Resolve the effective override for a specific path and rule id.
+    #[must_use]
     pub fn resolve(&self, path: &str, rule_id: &str) -> ResolvedRuleOverride {
         let Some(entries) = self.by_rule.get(rule_id) else {
             return ResolvedRuleOverride::default();

--- a/crates/diffguard-domain/src/suppression.rs
+++ b/crates/diffguard-domain/src/suppression.rs
@@ -43,6 +43,7 @@ pub struct Suppression {
 
 impl Suppression {
     /// Returns true if this suppression applies to the given rule ID.
+    #[must_use]
     pub fn suppresses(&self, rule_id: &str) -> bool {
         match &self.rule_ids {
             None => true, // Wildcard - suppress all

--- a/crates/diffguard-testkit/src/diff_builder.rs
+++ b/crates/diffguard-testkit/src/diff_builder.rs
@@ -87,6 +87,7 @@ impl DiffBuilder {
 }
 
 /// Helper struct for building a file within a diff.
+#[must_use]
 #[derive(Debug)]
 pub struct FileBuilderInProgress {
     diff_builder: DiffBuilder,
@@ -146,6 +147,7 @@ impl FileBuilderInProgress {
 }
 
 /// Helper struct for building a hunk within a file.
+#[must_use]
 #[derive(Debug)]
 pub struct HunkBuilderInProgress {
     file_in_progress: FileBuilderInProgress,


### PR DESCRIPTION
## Summary

Three `#[must_use]` additions:

1. **#483** — `RuleOverrideMatcher::resolve()` in `diffguard-domain/src/overrides.rs`: Returns `ResolvedRuleOverride` which callers must use. Without `#[must_use]`, callers who discard the result silently get default overrides.

2. **#476** — `Suppression::suppresses()` in `diffguard-domain/src/suppression.rs`: Returns `bool` indicating whether a finding should be suppressed. Without `#[must_use]`, callers who discard the result silently skip suppression checks.

3. **#512** — `FileBuilderInProgress` and `HunkBuilderInProgress` in `diffguard-testkit/src/diff_builder.rs`: Builder structs whose builder methods return `Self`. Without `#[must_use]`, chaining mistakes silently drop the builder.

`cargo clippy --workspace` → 0 warnings.

Closes #483, #476, #512.