### PR TITLE
fix(xtask): use map_or_else instead of map+unwrap_or_else (issue #488)

### DIFF
--- a/xtask/src/conform_real.rs
+++ b/xtask/src/conform_real.rs
@@ -684,15 +684,17 @@ fn test_schema_drift() -> Result<()> {
             .zip(contract_canonical.lines())
             .enumerate()
             .find(|(_, (a, b))| a != b)
-            .map(|(i, (a, b))| {
-                format!(
-                    "first divergence at line {}:\n  generated: {}\n  contract:  {}",
-                    i + 1,
-                    a,
-                    b
-                )
-            })
-            .unwrap_or_else(|| "files differ in length".to_string());
+            .map_or_else(
+                || "files differ in length".to_string(),
+                |(i, (a, b))| {
+                    format!(
+                        "first divergence at line {}:\n  generated: {}\n  contract:  {}",
+                        i + 1,
+                        a,
+                        b
+                    )
+                },
+            );
 
         bail!(
             "schema drift detected!\n\

--- a/xtask/src/conform_real.rs
+++ b/xtask/src/conform_real.rs
@@ -678,7 +678,9 @@ fn test_schema_drift() -> Result<()> {
     let contract_canonical = canonicalize_json(&contract_value);
 
     if generated_canonical != contract_canonical {
-        // Find first divergence line for diagnostics
+        // Find first divergence line for diagnostics.
+        // zip() stops at the shorter iterator, so if files differ only in length,
+        // find() returns None. In that case, map_or_else provides "files differ in length".
         let first_diff = generated_canonical
             .lines()
             .zip(contract_canonical.lines())
@@ -1354,6 +1356,10 @@ fn run_diffguard(dir: &Path, args: &[&str]) -> Result<Output> {
     Ok(output)
 }
 
+/// Ensures the diffguard binary is built in the current workspace.
+///
+/// Uses a OnceLock to memoize the build result, so cargo build is only invoked
+/// once even if multiple conformance tests call this function simultaneously.
 fn ensure_diffguard_built() -> Result<()> {
     static BUILD_RESULT: OnceLock<Result<(), String>> = OnceLock::new();
 
@@ -1374,6 +1380,11 @@ fn ensure_diffguard_built() -> Result<()> {
     }
 }
 
+/// Returns the path to the workspace root directory.
+///
+/// Traverses up from the xtask crate's manifest directory to find the Cargo.toml
+/// workspace root. The `unwrap_or` fallback handles the unlikely case where
+/// CARGO_MANIFEST_DIR is already the filesystem root.
 fn workspace_root() -> PathBuf {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     manifest_dir


### PR DESCRIPTION
Closes #488

## Summary

Fix the `clippy::map_unwrap_or` lint violation in `xtask/src/conform_real.rs` by replacing the inefficient `map(...).unwrap_or_else(...)` pattern with `map_or_else(...)`. This eliminates an intermediate Option allocation in the schema drift detection diagnostic formatter.

## ADR

- ADR: Use `map_or_else` instead of `map().unwrap_or_else()` for clippy::map_unwrap_or
- Status: Accepted

## Specs

- Specs: Fix clippy::map_unwrap_or at conform_real.rs:682

## What Changed

- `xtask/src/conform_real.rs`: Changed `.map(...).unwrap_or_else(...)` chain to `.map_or_else(...)` at lines 687-695
- The closure order is correct: default closure first, transformation closure second

## Test Results (so far)

- Clippy passes with `-W clippy::map_unwrap_or` (verified in prior build step)
- The xtask crate compiles without errors

## Friction Encountered

- Clippy lint only fires with explicit `-W clippy::map_unwrap_or` flag, not in default clippy runs
- The actual lint location was at lines 687-695, not 682 as initially described

## Notes

- Draft PR — not ready for review until GREEN tests confirmed
