### PR TITLE
fix: replace lossy usize→u32 casts with checked conversions

### DIFF
--- a/crates/diffguard-diff/src/unified.rs
+++ b/crates/diffguard-diff/src/unified.rs
@@ -115,6 +115,8 @@ pub struct DiffStats {
 pub enum DiffParseError {
     #[error("malformed hunk header: {0}")]
     MalformedHunkHeader(String),
+    #[error("diff stats overflow: {0}")]
+    Overflow(String),
 }
 
 /// Parse a unified diff (git-style) and return scoped lines in diff order.
@@ -331,8 +333,10 @@ pub fn parse_unified_diff(
     }
 
     let stats = DiffStats {
-        files: files.len() as u32,
-        lines: out.len() as u32,
+        files: u32::try_from(files.len())
+            .map_err(|_| DiffParseError::Overflow(format!("too many files (> {})", u32::MAX)))?,
+        lines: u32::try_from(out.len())
+            .map_err(|_| DiffParseError::Overflow(format!("too many lines (> {})", u32::MAX)))?,
     };
 
     Ok((out, stats))

--- a/crates/diffguard-domain/src/evaluate.rs
+++ b/crates/diffguard-domain/src/evaluate.rs
@@ -102,7 +102,7 @@ pub fn evaluate_lines_with_overrides_and_language(
         .iter()
         .map(|line| line.path.clone())
         .collect::<BTreeSet<_>>();
-    let lines_scanned = (input_lines.len().min(u32::MAX as usize)) as u32;
+    let lines_scanned = u32::try_from(input_lines.len()).unwrap_or(u32::MAX);
 
     let mut current_file: Option<String> = None;
     let mut current_lang = Language::Unknown;
@@ -295,7 +295,7 @@ pub fn evaluate_lines_with_overrides_and_language(
             let column = event
                 .match_start
                 .and_then(|start| byte_to_column(&prepared.line.content, start))
-                .map(|c| c as u32);
+                .and_then(|c| u32::try_from(c).ok());
             findings.push(Finding {
                 rule_id: rule.id.clone(),
                 severity: event.severity,

--- a/xtask/src/conform_real.rs
+++ b/xtask/src/conform_real.rs
@@ -684,15 +684,17 @@ fn test_schema_drift() -> Result<()> {
             .zip(contract_canonical.lines())
             .enumerate()
             .find(|(_, (a, b))| a != b)
-            .map(|(i, (a, b))| {
-                format!(
-                    "first divergence at line {}:\n  generated: {}\n  contract:  {}",
-                    i + 1,
-                    a,
-                    b
-                )
-            })
-            .unwrap_or_else(|| "files differ in length".to_string());
+            .map_or_else(
+                || "files differ in length".to_string(),
+                |(i, (a, b))| {
+                    format!(
+                        "first divergence at line {}:\n  generated: {}\n  contract:  {}",
+                        i + 1,
+                        a,
+                        b
+                    )
+                },
+            );
 
         bail!(
             "schema drift detected!\n\


### PR DESCRIPTION
## Summary

Replace lossy silent truncation casts with checked conversions that return errors.

**#475** — : `files.len() as u32` and `out.len() as u32` silently truncate on large diffs (>4B files/lines). Added `DiffParseError::Overflow` variant and used `u32::try_from()` with proper error.

**#481** — `diffguard-domain/src/evaluate.rs:298`: `byte_to_column(...).map(|c| c as u32)` silently truncates character columns >4B. Changed to `.and_then(|c| u32::try_from(c).ok())` — returns `None` for columns that overflow instead of bad data.

**#475 (partial)** — `evaluate.rs:105`: `(input_lines.len().min(u32::MAX as usize)) as u32` was already clamp-based but using a weird pattern. Simplified to `u32::try_from(input_lines.len()).unwrap_or(u32::MAX)`.

`cargo clippy --workspace` → 0 warnings. Closes #475, #481.