### PR TITLE
Add #[must_use] to parse_suppression functions

### DIFF
--- a/crates/diffguard-domain/src/suppression.rs
+++ b/crates/diffguard-domain/src/suppression.rs
@@ -66,6 +66,7 @@ const DIRECTIVE_PREFIX: &str = "diffguard:";
 ///
 /// This function should be called on the raw line BEFORE preprocessing
 /// (so that comment content is visible).
+#[must_use]
 pub fn parse_suppression(line: &str) -> Option<Suppression> {
     let lower = line.to_ascii_lowercase();
     lower
@@ -80,6 +81,7 @@ pub fn parse_suppression(line: &str) -> Option<Suppression> {
 /// `masked_comments` should be the output of the comments-only preprocessor
 /// for the same line and language. The directive is accepted only if the
 /// directive prefix is fully masked (spaces) in `masked_comments`.
+#[must_use]
 #[allow(clippy::collapsible_if)]
 pub fn parse_suppression_in_comments(line: &str, masked_comments: &str) -> Option<Suppression> {
     if line.len() != masked_comments.len() {


### PR DESCRIPTION
Fixes #307

Both `parse_suppression` and `parse_suppression_in_comments` return `Option<Suppression>` but were missing `#[must_use]`. Callers who ignore the return value silently drop suppressions, causing rules to fire incorrectly.