### PR TITLE
ci: accept URL-format issue references in Gate: Issue linked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
             echo "✅ chore/ branch — issue link waived for maintenance PRs"
             exit 0
           fi
-          if grep -qiE '(closes|fixes|resolves)\s+#[0-9]+' /tmp/pr-body.txt; then
+          if grep -qiE '(closes|fixes|resolves)(\s+#[0-9]+|\s+https?://[^/]+/[^/]+/issues/[0-9]+)' /tmp/pr-body.txt; then
             echo "✅ PR references an issue"
           else
             echo "❌ PR does not reference an issue"

--- a/crates/diffguard-domain/src/suppression.rs
+++ b/crates/diffguard-domain/src/suppression.rs
@@ -66,6 +66,7 @@ const DIRECTIVE_PREFIX: &str = "diffguard:";
 ///
 /// This function should be called on the raw line BEFORE preprocessing
 /// (so that comment content is visible).
+#[must_use]
 pub fn parse_suppression(line: &str) -> Option<Suppression> {
     let lower = line.to_ascii_lowercase();
     lower
@@ -80,6 +81,7 @@ pub fn parse_suppression(line: &str) -> Option<Suppression> {
 /// `masked_comments` should be the output of the comments-only preprocessor
 /// for the same line and language. The directive is accepted only if the
 /// directive prefix is fully masked (spaces) in `masked_comments`.
+#[must_use]
 #[allow(clippy::collapsible_if)]
 pub fn parse_suppression_in_comments(line: &str, masked_comments: &str) -> Option<Suppression> {
     if line.len() != masked_comments.len() {


### PR DESCRIPTION
Closes #565

Fixes the 'Gate: Issue linked' CI check to accept both 'Fixes #N' and 'Fixes: https://github.com/.../issues/N' formats. Both are valid GitHub issue references.