### PR TITLE
WIP: Add # Panics documentation to ConfigFile::built_in()

### DIFF
--- a/crates/diffguard-types/src/lib.rs
+++ b/crates/diffguard-types/src/lib.rs
@@ -245,6 +245,10 @@ impl ConfigFile {
     ///
     /// Rules are loaded from `rules/built_in.json` at compile time via `include_str!`.
     /// This ensures the JSON is embedded in the binary and avoids any I/O at runtime.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `built_in.json` cannot be parsed as valid JSON.
     #[must_use]
     pub fn built_in() -> Self {
         serde_json::from_str(include_str!("rules/built_in.json"))


### PR DESCRIPTION
Closes #493

## Summary
Adds missing # Panics documentation to ConfigFile::built_in() to satisfy clippy::missing_panics_doc. The function panics if built_in.json cannot be parsed as valid JSON.

## What Changed
- crates/diffguard-types/src/lib.rs: Added # Panics section to ConfigFile::built_in() documenting that it panics if built_in.json cannot be parsed.

## Test Results (so far)
clippy passes with no warnings.

## Friction Encountered
- Expected branch name feat/work-2b446664/configfile::built_in()-panics-but-is-mis is invalid (git does not allow :: in branch names). Created branch as feat/work-2b446664/configfile-built-in-panics-doc instead.
- Fix was applied to feat/work-e2b20a2c/orphaned-debug-artifact-bool-file which already has PR #602 for a different issue (#508).

## Notes
- Draft PR — not ready for review until GREEN tests confirmed