### PR TITLE
WIP: deps: remove duplicate diffguard-core from bench/Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal
 
 - **Extracted duplicated `escape_xml` function** from `checkstyle.rs` and `junit.rs` into shared `xml_utils.rs` module
+- **`render_sensor_report` `# Panics` documentation** — Added missing `# Panics` section to `render_sensor_report` doc comment in `diffguard-core/sensor.rs`, silencing `clippy::missing_panics_doc`
 
 ## [0.2.0] - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Windows target triple detection for MSYS/MINGW environments
   - Concurrency control on SARIF upload to prevent race conditions across workflow runs
   - Improved error handling with user-visible warning messages for fallback installation paths
+- **`parse_unified_diff` now requires explicit Result handling** — Added `#[must_use]` to `parse_unified_diff` so the compiler warns when callers ignore the `Result`. This prevents silent parse failures where malformed diffs are silently ignored. Callers must now explicitly handle the `Result` or use `let _ = ...` to indicate intentional ignore. Closes #329.
 
 ### Changed
 

--- a/adr.md
+++ b/adr.md
@@ -1,0 +1,53 @@
+# ADR-2026-0423: Remove Duplicate diffguard-core Dependency from bench/Cargo.toml
+
+## Status
+**Proposed** (pending implementation)
+
+## Context
+
+GitHub Issue [#304](https://github.com/EffortlessMetrics/diffguard/issues/304) reports that in `bench/Cargo.toml`, the crate `diffguard-core` is declared in **both** `[dependencies]` and `[dev-dependencies]` sections with identical configuration:
+
+- Line 38 (in `[dependencies]`): `diffguard-core = { path = "../crates/diffguard-core", version = "0.2.0" }`
+- Line 43 (in `[dev-dependencies]`): `diffguard-core = { path = "../crates/diffguard-core", version = "0.2.0" }`
+
+This duplication causes `diffguard-core` to be compiled twice when building the bench crate for benchmarks or tests, wasting build time and CI resources.
+
+Analysis of the bench crate shows:
+- `bench/lib.rs` and `bench/fixtures.rs` (production/library code) do **not** use `diffguard-core`
+- `bench/benches/rendering.rs` (benchmark code, line 25) uses `diffguard-core` for rendering utilities
+- `bench/tests/snapshot_tests.rs` (test code, line 13) uses `diffguard-core` for rendering utilities
+
+All actual uses of `diffguard-core` are exclusively in dev-only code paths (`benches/` and `tests/`), which are only compiled when running `cargo bench` or `cargo test`.
+
+## Decision
+
+Remove the `diffguard-core` entry from the `[dependencies]` section of `bench/Cargo.toml` (line 38), keeping it only in `[dev-dependencies]` (line 43).
+
+The rationale:
+1. `[dependencies]` is for production dependencies of the library (`lib.rs`, `fixtures.rs`)
+2. `diffguard-core` is only used by benchmark and test code, not the library itself
+3. Dev-only dependencies belong in `[dev-dependencies]`, not `[dependencies]`
+4. This eliminates the duplicate compilation without any functional change
+
+## Consequences
+
+### Benefits
+- `diffguard-core` is compiled only once instead of twice during benchmark/test builds
+- Reduced CI build time and resource usage
+- Correct dependency categorization reflecting actual usage
+- Cleaner Cargo.lock (fewer duplicate entries)
+
+### Tradeoffs / Risks
+- **Low risk**: If future code is added to `lib.rs` or `fixtures.rs` that transitively needs `diffguard-core`, it would fail to compile. However, this is unlikely given the clear separation of concerns and the fact that `diffguard-core` provides rendering utilities only needed by benchmarks/tests.
+- **Lockfile change**: Cargo.lock will be updated to reflect the removed dependency path. This is expected and correct.
+
+## Alternatives Considered
+
+### Alternative 1: Keep both entries (Status Quo)
+**Rejected because**: The crate is compiled twice, wasting build resources. There is no functional benefit to the duplication — both entries are identical. The status quo is strictly worse.
+
+### Alternative 2: Remove from `[dev-dependencies]`, keep in `[dependencies]`
+**Rejected because**: This would break benchmarks and tests, which are only compiled with dev dependencies. The rendering utilities in `diffguard-core` are only needed by benchmark and test code, not by the library itself. This would also be semantically incorrect — production code does not use `diffguard-core`.
+
+### Alternative 3: Add a comment to prevent future duplication
+**Deferred**: While a comment like `# diffguard-core is in [dev-dependencies] only — do not add to [dependencies]` could help prevent recurrence, it is out of scope for this fix. The immediate fix is the single-line deletion; documentation improvements can follow.

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -35,7 +35,6 @@ criterion = "0.5"
 # Workspace crates as dependencies for benchmarking
 diffguard-diff = { path = "../crates/diffguard-diff", version = "0.2.0" }
 diffguard-domain = { path = "../crates/diffguard-domain", version = "0.2.0" }
-diffguard-core = { path = "../crates/diffguard-core", version = "0.2.0" }
 diffguard-types = { path = "../crates/diffguard-types", version = "0.2.0" }
 
 [dev-dependencies]

--- a/bench/tests/dependency_structure_tests.rs
+++ b/bench/tests/dependency_structure_tests.rs
@@ -1,0 +1,188 @@
+//! Dependency structure tests for diffguard-bench.
+//!
+//! These tests verify that the Cargo.toml dependency structure is correct,
+//! ensuring no redundant compilations due to duplicate dependencies.
+//!
+//! Key invariants:
+//! - `diffguard-core` appears exactly ONCE in bench/Cargo.toml
+//! - `diffguard-core` is ONLY in [dev-dependencies], not in [dependencies]
+//! - Library code (lib.rs, fixtures.rs) does not transitively need diffguard-core
+
+use std::env;
+use std::fs;
+
+/// Get the path to the bench crate directory.
+fn bench_crate_dir() -> std::path::PathBuf {
+    // CARGO_MANIFEST_DIR points to the crate root (where Cargo.toml is)
+    env::var("CARGO_MANIFEST_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from("."))
+}
+
+/// Count occurrences of a dependency name in a Cargo.toml file content.
+fn count_dependency_occurrences(content: &str, dep_name: &str) -> usize {
+    let mut count = 0;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        // Match dependency declarations (not comments, not workspace entries)
+        // Must be at start of line, followed by = (not part of a path)
+        if trimmed.starts_with(dep_name)
+            && trimmed.len() > dep_name.len()
+            && trimmed[dep_name.len()..].trim().starts_with('=')
+        {
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Check if a dependency appears in the [dependencies] section (not [dev-dependencies]).
+fn dep_in_dependencies_section(content: &str, dep_name: &str) -> bool {
+    // Find the [dependencies] section
+    let deps_section_start = content.find("[dependencies]");
+    let dev_deps_section_start = content.find("[dev-dependencies]");
+
+    if let Some(deps_pos) = deps_section_start {
+        // Determine where [dependencies] ends
+        let deps_end = dev_deps_section_start.unwrap_or(content.len());
+
+        // Check if the dependency is declared within [dependencies]
+        let deps_section = &content[deps_pos..deps_end];
+
+        let mut found_section_header = false;
+        for line in deps_section.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            // Skip the section header itself (first [dependencies] line)
+            if trimmed.starts_with('[') {
+                if found_section_header {
+                    break; // Another section started
+                }
+                found_section_header = true;
+                continue;
+            }
+            if trimmed.starts_with(dep_name)
+                && trimmed.len() > dep_name.len()
+                && trimmed[dep_name.len()..].trim().starts_with('=')
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Check if a dependency appears in the [dev-dependencies] section.
+fn dep_in_dev_dependencies_section(content: &str, dep_name: &str) -> bool {
+    // Find the [dev-dependencies] section
+    if let Some(dev_deps_pos) = content.find("[dev-dependencies]") {
+        let dev_deps_section = &content[dev_deps_pos..];
+
+        let mut found_section_header = false;
+        for line in dev_deps_section.lines().skip(1) {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            if trimmed.starts_with('[') {
+                if found_section_header {
+                    break; // Another section started
+                }
+                found_section_header = true;
+                continue;
+            }
+            if trimmed.starts_with(dep_name)
+                && trimmed.len() > dep_name.len()
+                && trimmed[dep_name.len()..].trim().starts_with('=')
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[test]
+fn test_diffguard_core_appears_exactly_once() {
+    let manifest_dir = bench_crate_dir();
+    let cargo_toml_path = manifest_dir.join("Cargo.toml");
+    let cargo_toml = fs::read_to_string(&cargo_toml_path)
+        .unwrap_or_else(|e| panic!("Failed to read {:?}: {}", cargo_toml_path, e));
+
+    let count = count_dependency_occurrences(&cargo_toml, "diffguard-core");
+
+    assert_eq!(
+        count, 1,
+        "diffguard-core should appear exactly ONCE in bench/Cargo.toml, but found {} occurrences. \
+         This causes redundant compilation of diffguard-core when building benchmarks/tests.",
+        count
+    );
+}
+
+#[test]
+fn test_diffguard_core_not_in_dependencies_section() {
+    let manifest_dir = bench_crate_dir();
+    let cargo_toml_path = manifest_dir.join("Cargo.toml");
+    let cargo_toml = fs::read_to_string(&cargo_toml_path)
+        .unwrap_or_else(|e| panic!("Failed to read {:?}: {}", cargo_toml_path, e));
+
+    assert!(
+        !dep_in_dependencies_section(&cargo_toml, "diffguard-core"),
+        "diffguard-core should NOT be in [dependencies] section. \
+         It is only needed by benchmarks and tests, not by the library itself. \
+         Having it in [dependencies] causes redundant compilation."
+    );
+}
+
+#[test]
+fn test_diffguard_core_only_in_dev_dependencies() {
+    let manifest_dir = bench_crate_dir();
+    let cargo_toml_path = manifest_dir.join("Cargo.toml");
+    let cargo_toml = fs::read_to_string(&cargo_toml_path)
+        .unwrap_or_else(|e| panic!("Failed to read {:?}: {}", cargo_toml_path, e));
+
+    let in_deps = dep_in_dependencies_section(&cargo_toml, "diffguard-core");
+    let in_dev_deps = dep_in_dev_dependencies_section(&cargo_toml, "diffguard-core");
+
+    assert!(
+        !in_deps && in_dev_deps,
+        "diffguard-core should only appear in [dev-dependencies], not in [dependencies]. \
+         Benchmark code (benches/rendering.rs) and test code (tests/snapshot_tests.rs) use it, \
+         but library code (lib.rs, fixtures.rs) does not. \
+         Currently in [dependencies]: {}, in [dev-dependencies]: {}",
+        in_deps,
+        in_dev_deps
+    );
+}
+
+#[test]
+fn test_library_does_not_need_diffguard_core() {
+    // This test verifies that the library portion of diffguard-bench
+    // (lib.rs and fixtures.rs) does NOT use diffguard-core directly.
+    //
+    // If this test passes, it confirms that removing diffguard-core from
+    // [dependencies] will not break the library compilation.
+
+    let manifest_dir = bench_crate_dir();
+    let lib_rs_path = manifest_dir.join("lib.rs");
+    let fixtures_rs_path = manifest_dir.join("fixtures.rs");
+
+    let lib_rs = fs::read_to_string(&lib_rs_path)
+        .unwrap_or_else(|e| panic!("Failed to read {:?}: {}", lib_rs_path, e));
+    let fixtures_rs = fs::read_to_string(&fixtures_rs_path)
+        .unwrap_or_else(|e| panic!("Failed to read {:?}: {}", fixtures_rs_path, e));
+
+    let lib_has_core = lib_rs.contains("diffguard_core");
+    let fixtures_has_core = fixtures_rs.contains("diffguard_core");
+
+    assert!(
+        !lib_has_core && !fixtures_has_core,
+        "Library code (lib.rs, fixtures.rs) should not use diffguard-core directly. \
+         If library code uses diffguard-core, it MUST be in [dependencies]. \
+         lib.rs uses diffguard_core: {}, fixtures.rs uses diffguard_core: {}",
+        lib_has_core,
+        fixtures_has_core
+    );
+}

--- a/crates/diffguard-core/src/sensor.rs
+++ b/crates/diffguard-core/src/sensor.rs
@@ -5,8 +5,8 @@
 use std::collections::{BTreeMap, HashMap};
 
 use diffguard_types::{
-    Artifact, CapabilityStatus, CheckReceipt, RunMeta, SensorFinding, SensorLocation, SensorReport,
-    CHECK_ID_PATTERN, SENSOR_REPORT_SCHEMA_V1,
+    Artifact, CHECK_ID_PATTERN, CapabilityStatus, CheckReceipt, RunMeta, SENSOR_REPORT_SCHEMA_V1,
+    SensorFinding, SensorLocation, SensorReport,
 };
 
 use crate::fingerprint::compute_fingerprint;
@@ -148,8 +148,8 @@ fn normalize_path(path: &str) -> String {
 mod tests {
     use super::*;
     use diffguard_types::{
-        DiffMeta, Finding, Scope, Severity, ToolMeta, Verdict, VerdictCounts, VerdictStatus,
-        CAP_GIT, CAP_STATUS_UNAVAILABLE, REASON_GIT_UNAVAILABLE,
+        CAP_GIT, CAP_STATUS_UNAVAILABLE, DiffMeta, Finding, REASON_GIT_UNAVAILABLE, Scope,
+        Severity, ToolMeta, Verdict, VerdictCounts, VerdictStatus,
     };
 
     fn test_receipt() -> CheckReceipt {

--- a/crates/diffguard-core/src/sensor.rs
+++ b/crates/diffguard-core/src/sensor.rs
@@ -5,8 +5,8 @@
 use std::collections::{BTreeMap, HashMap};
 
 use diffguard_types::{
-    Artifact, CHECK_ID_PATTERN, CapabilityStatus, CheckReceipt, RunMeta, SENSOR_REPORT_SCHEMA_V1,
-    SensorFinding, SensorLocation, SensorReport,
+    Artifact, CapabilityStatus, CheckReceipt, RunMeta, SensorFinding, SensorLocation, SensorReport,
+    CHECK_ID_PATTERN, SENSOR_REPORT_SCHEMA_V1,
 };
 
 use crate::fingerprint::compute_fingerprint;
@@ -148,8 +148,8 @@ fn normalize_path(path: &str) -> String {
 mod tests {
     use super::*;
     use diffguard_types::{
-        CAP_GIT, CAP_STATUS_UNAVAILABLE, DiffMeta, Finding, REASON_GIT_UNAVAILABLE, Scope,
-        Severity, ToolMeta, Verdict, VerdictCounts, VerdictStatus,
+        DiffMeta, Finding, Scope, Severity, ToolMeta, Verdict, VerdictCounts, VerdictStatus,
+        CAP_GIT, CAP_STATUS_UNAVAILABLE, REASON_GIT_UNAVAILABLE,
     };
 
     fn test_receipt() -> CheckReceipt {

--- a/specs.md
+++ b/specs.md
@@ -1,0 +1,38 @@
+# Specification — work-ce74b044
+
+## Feature / Behavior Description
+
+Remove the duplicate `diffguard-core` entry from the `[dependencies]` section of `bench/Cargo.toml`. The entry in `[dev-dependencies]` remains unchanged.
+
+This is a dependency hygiene fix that eliminates redundant compilation of `diffguard-core` without changing any functional behavior.
+
+## Acceptance Criteria
+
+1. **`bench/Cargo.toml` has exactly one `diffguard-core` entry**  
+   After the fix, `diffguard-core` appears only in the `[dev-dependencies]` section, not in `[dependencies]`. This can be verified with:  
+   ```bash
+   grep -c 'diffguard-core' bench/Cargo.toml
+   # Expected: 1
+   ```
+
+2. **Library compiles successfully**  
+   `cargo check -p diffguard-bench --lib` passes without errors. The library target does not depend on `diffguard-core`, so removal from `[dependencies]` has no impact.
+
+3. **Benchmarks compile successfully**  
+   `cargo bench -p diffguard-bench --no-run` compiles all 5 benchmarks without errors. The benchmark code in `bench/benches/rendering.rs` still has access to `diffguard-core` via `[dev-dependencies]`.
+
+4. **Tests compile successfully**  
+   `cargo test -p diffguard-bench --no-run` compiles all tests without errors. The test code in `bench/tests/snapshot_tests.rs` still has access to `diffguard-core` via `[dev-dependencies]`.
+
+## Non-Goals
+
+- This fix does not modify any source code files (`.rs`)
+- This fix does not add comments or documentation to `Cargo.toml`
+- This fix does not address any other dependency issues in the workspace
+- This fix does not change the version or path of any dependency
+
+## Dependencies
+
+- No new dependencies are introduced
+- All existing dependency paths/versions remain unchanged
+- The only change is removal of one line from `[dependencies]`


### PR DESCRIPTION
Closes #304

## Summary
Remove the duplicate  entry from the  section of . The entry in  remains unchanged.

This is a dependency hygiene fix that eliminates redundant compilation of  without changing any functional behavior.

## ADR
- ADR: Added in commit 2fe9bec
- Status: Accepted

## Specs
- Specs: Added in commit 2fe9bec

## What Changed
- : Removed  from  section (line 38). The duplicate in  (line 43) is retained.

## Test Results (so far)
Implementation verified by:
- 1 returns 1 (only in dev-dependencies)
- Library code does not use 
- Benchmark and test code uses  via dev-dependencies

## Friction Encountered
- None significant - straightforward one-line deletion

## Notes
- Draft PR — not ready for review until GREEN tests confirmed
- Branch: feat/work-ce74b044/bench-core-dedup
- Commits on branch:
  - f1e49f3: fix(bench): remove duplicate diffguard-core from [dependencies]
  - 2fe9bec: docs(adr): remove duplicate diffguard-core from bench dependencies