### PR TITLE
feat(diffguard-types): add ignore_comments and ignore_strings to Defaults struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Windows target triple detection for MSYS/MINGW environments
   - Concurrency control on SARIF upload to prevent race conditions across workflow runs
   - Improved error handling with user-visible warning messages for fallback installation paths
+- **`parse_unified_diff` now requires explicit Result handling** — Added `#[must_use]` to `parse_unified_diff` so the compiler warns when callers ignore the `Result`. This prevents silent parse failures where malformed diffs are silently ignored. Callers must now explicitly handle the `Result` or use `let _ = ...` to indicate intentional ignore. Closes #329.
 
 ### Changed
 

--- a/crates/diffguard-analytics/tests/prop_working.rs
+++ b/crates/diffguard-analytics/tests/prop_working.rs
@@ -1,0 +1,278 @@
+//! Property-based tests for diffguard-analytics
+//!
+//! Feature: comprehensive-test-coverage, Property: Baseline Analytics
+//!
+//! These tests verify invariants about fingerprint computation, baseline
+//! creation, normalization, and merging that the baseline_receipt fuzz
+//! target depends on.
+
+use proptest::prelude::*;
+
+use diffguard_analytics::{
+    FALSE_POSITIVE_BASELINE_SCHEMA_V1, FalsePositiveBaseline, FalsePositiveEntry,
+    baseline_from_receipt, false_positive_fingerprint_set, fingerprint_for_finding,
+    merge_false_positive_baselines, normalize_false_positive_baseline,
+};
+use diffguard_types::{
+    CHECK_SCHEMA_V1, CheckReceipt, DiffMeta, Finding, Scope, Severity, ToolMeta, Verdict,
+    VerdictCounts, VerdictStatus,
+};
+
+// ============================================================================
+// Proptest Strategies for generating test data
+// ============================================================================
+
+/// Strategy for generating valid Severity values.
+fn arb_severity() -> impl Strategy<Value = Severity> {
+    prop_oneof![
+        Just(Severity::Info),
+        Just(Severity::Warn),
+        Just(Severity::Error),
+    ]
+}
+
+/// Strategy for generating rule_id strings.
+fn arb_rule_id() -> impl Strategy<Value = String> {
+    prop::string::string_regex("[a-z][a-z0-9_.]{0,30}")
+        .expect("valid regex")
+        .prop_filter("must not be empty", |s| !s.is_empty())
+}
+
+/// Strategy for generating path strings.
+fn arb_path() -> impl Strategy<Value = String> {
+    prop::string::string_regex("[a-zA-Z][a-zA-Z0-9_/.-]{0,50}")
+        .expect("valid regex")
+        .prop_filter("must not be empty", |s| !s.is_empty())
+}
+
+/// Strategy for generating match_text strings.
+fn arb_match_text() -> impl Strategy<Value = String> {
+    prop::string::string_regex("[a-zA-Z0-9_ ]{0,100}").expect("valid regex")
+}
+
+/// Strategy for generating valid Finding.
+fn arb_finding() -> impl Strategy<Value = Finding> {
+    (
+        arb_rule_id(),
+        arb_severity(),
+        prop::string::string_regex("[a-zA-Z0-9 .,!?]{1,100}").expect("valid regex"),
+        arb_path(),
+        1u32..10000,
+        prop::option::of(1u32..200),
+        arb_match_text(),
+        prop::string::string_regex("[a-zA-Z0-9 .,!?]{0,200}").expect("valid regex"),
+    )
+        .prop_map(
+            |(rule_id, severity, message, path, line, column, match_text, snippet)| Finding {
+                rule_id,
+                severity,
+                message,
+                path,
+                line,
+                column,
+                match_text,
+                snippet,
+            },
+        )
+}
+
+/// Strategy for generating a complete CheckReceipt.
+fn arb_check_receipt() -> impl Strategy<Value = CheckReceipt> {
+    prop::collection::vec(arb_finding(), 0..20).prop_map(|findings| {
+        let mut info = 0u32;
+        let mut warn = 0u32;
+        let mut error = 0u32;
+        for f in &findings {
+            match f.severity {
+                Severity::Info => info += 1,
+                Severity::Warn => warn += 1,
+                Severity::Error => error += 1,
+            }
+        }
+        let status = if error > 0 {
+            VerdictStatus::Fail
+        } else if warn > 0 {
+            VerdictStatus::Warn
+        } else {
+            VerdictStatus::Pass
+        };
+        CheckReceipt {
+            schema: CHECK_SCHEMA_V1.to_string(),
+            tool: ToolMeta {
+                name: "diffguard".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            diff: DiffMeta {
+                base: "origin/main".to_string(),
+                head: "HEAD".to_string(),
+                context_lines: 3,
+                scope: Scope::Added,
+                files_scanned: 1,
+                lines_scanned: findings.len() as u32,
+            },
+            findings,
+            verdict: Verdict {
+                status,
+                counts: VerdictCounts {
+                    info,
+                    warn,
+                    error,
+                    suppressed: 0,
+                },
+                reasons: vec![],
+            },
+            timing: None,
+        }
+    })
+}
+
+/// Strategy for generating a valid FalsePositiveEntry.
+fn arb_baseline_entry() -> impl Strategy<Value = FalsePositiveEntry> {
+    (
+        prop::string::string_regex("[a-f0-9]{64}").expect("valid sha256 hex"),
+        arb_rule_id(),
+        arb_path(),
+        1u32..10000,
+        prop::option::of(
+            prop::string::string_regex("[a-zA-Z0-9 .,!?]{0,200}").expect("valid regex"),
+        ),
+    )
+        .prop_map(
+            |(fingerprint, rule_id, path, line, note)| FalsePositiveEntry {
+                fingerprint,
+                rule_id,
+                path,
+                line,
+                note,
+            },
+        )
+}
+
+/// Strategy for generating a valid FalsePositiveBaseline.
+fn arb_baseline() -> impl Strategy<Value = FalsePositiveBaseline> {
+    prop::collection::vec(arb_baseline_entry(), 0..20).prop_map(|entries| {
+        let schema = FALSE_POSITIVE_BASELINE_SCHEMA_V1.to_string();
+        FalsePositiveBaseline { schema, entries }
+    })
+}
+
+    #[test]
+    fn property_merge_contains_union_of_fingerprints(
+        baseline1 in arb_baseline(),
+        baseline2 in arb_baseline(),
+    ) {
+        let merged = merge_false_positive_baselines(&baseline1, &baseline2);
+        let fps1: std::collections::HashSet<_> =
+            baseline1.entries.iter().map(|e| e.fingerprint.clone()).collect();
+        let fps2: std::collections::HashSet<_> =
+            baseline2.entries.iter().map(|e| e.fingerprint.clone()).collect();
+        let expected_union: std::collections::HashSet<_> =
+            fps1.union(&fps2).cloned().collect();
+        let merged_fps: std::collections::HashSet<_> =
+            merged.entries.iter().map(|e| e.fingerprint.clone()).collect();
+        prop_assert_eq!(
+            merged_fps, expected_union,
+            "Merged baseline should contain union of fingerprints"
+        );
+    }
+
+    #[test]
+    fn property_merge_preserves_existing_notes() {
+        let existing = FalsePositiveBaseline {
+            schema: FALSE_POSITIVE_BASELINE_SCHEMA_V1.to_string(),
+            entries: vec![FalsePositiveEntry {
+                fingerprint: "abc123".to_string(),
+                rule_id: "rule1".to_string(),
+                path: "file1.rs".to_string(),
+                line: 1,
+                note: Some("curated note".to_string()),
+            }],
+        };
+        let incoming = FalsePositiveBaseline {
+            schema: FALSE_POSITIVE_BASELINE_SCHEMA_V1.to_string(),
+            entries: vec![FalsePositiveEntry {
+                fingerprint: "abc123".to_string(),
+                rule_id: "rule1".to_string(),
+                path: "file1.rs".to_string(),
+                line: 1,
+                note: None,
+            }],
+        };
+        let merged = merge_false_positive_baselines(&existing, &incoming);
+        prop_assert_eq!(merged.entries.len(), 1);
+        prop_assert_eq!(
+            merged.entries[0].note.as_deref(),
+            Some("curated note"),
+            "Existing note should be preserved"
+        );
+    }
+
+    #[test]
+    fn property_merge_preserves_existing_fields() {
+        let existing = FalsePositiveBaseline {
+            schema: FALSE_POSITIVE_BASELINE_SCHEMA_V1.to_string(),
+            entries: vec![FalsePositiveEntry {
+                fingerprint: "abc123".to_string(),
+                rule_id: "rule1".to_string(),
+                path: "file1.rs".to_string(),
+                line: 1,
+                note: None,
+            }],
+        };
+        let incoming = FalsePositiveBaseline {
+            schema: FALSE_POSITIVE_BASELINE_SCHEMA_V1.to_string(),
+            entries: vec![FalsePositiveEntry {
+                fingerprint: "abc123".to_string(),
+                rule_id: "".to_string(),
+                path: "".to_string(),
+                line: 0,
+                note: None,
+            }],
+        };
+        let merged = merge_false_positive_baselines(&existing, &incoming);
+        prop_assert_eq!(merged.entries.len(), 1);
+        prop_assert_eq!(merged.entries[0].rule_id, "rule1");
+        prop_assert_eq!(merged.entries[0].path, "file1.rs");
+        prop_assert_eq!(merged.entries[0].line, 1);
+    }
+}
+
+// ============================================================================
+// Property: Fingerprint Set
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    #[test]
+    fn property_fingerprint_set_contains_all_fingerprints(baseline in arb_baseline()) {
+        let set = false_positive_fingerprint_set(&baseline);
+        prop_assert_eq!(
+            set.len(),
+            baseline.entries.len(),
+            "Fingerprint set size should match baseline entries count"
+        );
+        for entry in &baseline.entries {
+            prop_assert!(
+                set.contains(&entry.fingerprint),
+                "Set should contain fingerprint"
+            );
+        }
+    }
+
+    #[test]
+    fn property_fingerprint_set_no_duplicates(baseline in arb_baseline()) {
+        let set = false_positive_fingerprint_set(&baseline);
+        let unique_count = baseline
+            .entries
+            .iter()
+            .map(|e| &e.fingerprint)
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        prop_assert_eq!(
+            set.len(),
+            unique_count,
+            "Set should have no duplicate fingerprints"
+        );
+    }
+}

--- a/crates/diffguard-analytics/tests/properties.rs
+++ b/crates/diffguard-analytics/tests/properties.rs
@@ -1,0 +1,533 @@
+//! Property-based tests for diffguard-analytics
+//!
+//! Feature: comprehensive-test-coverage, Property: Baseline Analytics
+//!
+//! These tests verify invariants about fingerprint computation, baseline
+//! creation, normalization, and merging that the baseline_receipt fuzz
+//! target depends on.
+//!
+//! ## Invariants Tested
+//!
+//! ### Fingerprint (DETERMINISTIC)
+//! - Same finding always produces the same fingerprint
+//! - Fingerprint is exactly 64 hex characters (SHA-256)
+//! - Fingerprint is valid hexadecimal
+//!
+//! ### Baseline (PRESERVES + DEDUPLICATES)
+//! - Schema is always "diffguard.false_positive_baseline.v1"
+//! - Each finding produces an entry with matching fingerprint
+//! - Duplicate findings are deduplicated
+//!
+//! ### Normalization (IDEMPOTENT + SORTED)
+//! - Normalizing twice gives same result (idempotent)
+//! - Entries are sorted by fingerprint, rule_id, path, line
+//! - Schema is set if empty
+//!
+//! ### Merge (COMMUTATIVE + UNION)
+//! - Merging is commutative: A + B = B + A
+//! - Merging is associative: (A + B) + C = A + (B + C)
+//! - Result contains union of fingerprints
+//! - Existing entries (from base) are preserved
+
+use proptest::prelude::*;
+
+use diffguard_analytics::{
+    baseline_from_receipt, false_positive_fingerprint_set, fingerprint_for_finding,
+    merge_false_positive_baselines, normalize_false_positive_baseline,
+    FalsePositiveBaseline, FalsePositiveEntry, FALSE_POSITIVE_BASELINE_SCHEMA_V1,
+};
+use diffguard_types::{
+    CheckReceipt, DiffMeta, Finding, Scope, Severity, ToolMeta, Verdict, VerdictCounts,
+    VerdictStatus, CHECK_SCHEMA_V1,
+};
+
+// ============================================================================
+// Proptest Strategies for generating test data
+// ============================================================================
+
+/// Strategy for generating valid Severity values.
+fn arb_severity() -> impl Strategy<Value = Severity> {
+    prop_oneof![Just(Severity::Info), Just(Severity::Warn), Just(Severity::Error),]
+}
+
+/// Strategy for generating rule_id strings.
+fn arb_rule_id() -> impl Strategy<Value = String> {
+    prop::string::string_regex("[a-z][a-z0-9_.]{0,30}")
+        .expect("valid regex")
+        .prop_filter("must not be empty", |s| !s.is_empty())
+}
+
+/// Strategy for generating path strings.
+fn arb_path() -> impl Strategy<Value = String> {
+    prop::string::string_regex("[a-zA-Z][a-zA-Z0-9_/.-]{0,50}")
+        .expect("valid regex")
+        .prop_filter("must not be empty", |s| !s.is_empty())
+}
+
+/// Strategy for generating match_text strings.
+fn arb_match_text() -> impl Strategy<Value = String> {
+    prop::string::string_regex("[a-zA-Z0-9_ ]{0,100}")
+        .expect("valid regex")
+}
+
+/// Strategy for generating valid Finding.
+fn arb_finding() -> impl Strategy<Value = Finding> {
+    (
+        arb_rule_id(),
+        arb_severity(),
+        prop::string::string_regex("[a-zA-Z0-9 .,!?]{1,100}").expect("valid regex"), // message
+        arb_path(),
+        1u32..10000,
+        prop::option::of(1u32..200),
+        arb_match_text(),
+        prop::string::string_regex("[a-zA-Z0-9 .,!?]{0,200}").expect("valid regex"), // snippet
+    )
+        .prop_map(|(rule_id, severity, message, path, line, column, match_text, snippet)| {
+            Finding {
+                rule_id,
+                severity,
+                message,
+                path,
+                line,
+                column,
+                match_text,
+                snippet,
+            }
+        })
+}
+
+/// Strategy for generating a complete CheckReceipt.
+fn arb_check_receipt() -> impl Strategy<Value = CheckReceipt> {
+    prop::collection::vec(arb_finding(), 0..20).prop_map(|findings| {
+        let mut info = 0u32;
+        let mut warn = 0u32;
+        let mut error = 0u32;
+        for f in &findings {
+            match f.severity {
+                Severity::Info => info += 1,
+                Severity::Warn => warn += 1,
+                Severity::Error => error += 1,
+            }
+        }
+        let status = if error > 0 {
+            VerdictStatus::Fail
+        } else if warn > 0 {
+            VerdictStatus::Warn
+        } else {
+            VerdictStatus::Pass
+        };
+        CheckReceipt {
+            schema: CHECK_SCHEMA_V1.to_string(),
+            tool: ToolMeta {
+                name: "diffguard".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            diff: DiffMeta {
+                base: "origin/main".to_string(),
+                head: "HEAD".to_string(),
+                context_lines: 3,
+                scope: Scope::Added,
+                files_scanned: 1,
+                lines_scanned: findings.len() as u32,
+            },
+            findings,
+            verdict: Verdict {
+                status,
+                counts: VerdictCounts {
+                    info,
+                    warn,
+                    error,
+                    suppressed: 0,
+                },
+                reasons: vec![],
+            },
+            timing: None,
+        }
+    })
+}
+
+/// Strategy for generating a valid FalsePositiveEntry.
+fn arb_baseline_entry() -> impl Strategy<Value = FalsePositiveEntry> {
+    (
+        prop::string::string_regex("[a-f0-9]{64}").expect("valid sha256 hex"),
+        arb_rule_id(),
+        arb_path(),
+        1u32..10000,
+        prop::option::of(prop::string::string_regex("[a-zA-Z0-9 .,!?]{0,200}").expect("valid regex")),
+    )
+        .prop_map(|(fingerprint, rule_id, path, line, note)| FalsePositiveEntry {
+            fingerprint,
+            rule_id,
+            path,
+            line,
+            note,
+        })
+}
+
+/// Strategy for generating a valid FalsePositiveBaseline.
+fn arb_baseline() -> impl Strategy<Value = FalsePositiveBaseline> {
+    prop::collection::vec(arb_baseline_entry(), 0..20).prop_map(|entries| {
+        let schema = FALSE_POSITIVE_BASELINE_SCHEMA_V1.to_string();
+        FalsePositiveBaseline { schema, entries }
+    })
+}
+
+// ============================================================================
+// Property: Fingerprint Determinism (DETERMINISTIC)
+// ============================================================================
+
+proptest! {
+    #[test]
+    fn property_fingerprint_is_deterministic(finding in arb_finding()) {
+        let fp1 = fingerprint_for_finding(&finding);
+        let fp2 = fingerprint_for_finding(&finding);
+        prop_assert_eq!(
+            fp1, fp2,
+            "Same finding should produce same fingerprint"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_length_is_64(finding in arb_finding()) {
+        let fp = fingerprint_for_finding(&finding);
+        prop_assert_eq!(
+            fp.len(), 64,
+            "SHA-256 fingerprint should be 64 hex chars, got {} chars",
+            fp.len()
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_is_valid_hex(finding in arb_finding()) {
+        let fp = fingerprint_for_finding(&finding);
+        prop_assert!(
+            fp.chars().all(|c| c.is_ascii_hexdigit()),
+            "Fingerprint should be valid hex: {}",
+            fp
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_changes_with_rule_id(
+        base_finding in arb_finding(),
+        new_rule_id in arb_rule_id(),
+    ) {
+        let finding1 = base_finding.clone();
+        let mut finding2 = base_finding;
+        finding2.rule_id = new_rule_id;
+
+        let fp1 = fingerprint_for_finding(&finding1);
+        let fp2 = fingerprint_for_finding(&finding2);
+
+        prop_assert_ne!(
+            fp1, fp2,
+            "Different rule_id should produce different fingerprint"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_changes_with_path(
+        base_finding in arb_finding(),
+        new_path in arb_path(),
+    ) {
+        let finding1 = base_finding.clone();
+        let mut finding2 = base_finding;
+        finding2.path = new_path;
+
+        let fp1 = fingerprint_for_finding(&finding1);
+        let fp2 = fingerprint_for_finding(&finding2);
+
+        prop_assert_ne!(
+            fp1, fp2,
+            "Different path should produce different fingerprint"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_changes_with_line(
+        base_finding in arb_finding(),
+        new_line in 1u32..10000,
+    ) {
+        let finding1 = base_finding.clone();
+        let mut finding2 = base_finding;
+        finding2.line = new_line;
+
+        let fp1 = fingerprint_for_finding(&finding1);
+        let fp2 = fingerprint_for_finding(&finding2);
+
+        prop_assert_ne!(
+            fp1, fp2,
+            "Different line should produce different fingerprint"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_changes_with_match_text(
+        base_finding in arb_finding(),
+        new_match_text in arb_match_text(),
+    ) {
+        let finding1 = base_finding.clone();
+        let mut finding2 = base_finding;
+        finding2.match_text = new_match_text;
+
+        let fp1 = fingerprint_for_finding(&finding1);
+        let fp2 = fingerprint_for_finding(&finding2);
+
+        prop_assert_ne!(
+            fp1, fp2,
+            "Different match_text should produce different fingerprint"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_ignores_message(
+        base_finding in arb_finding(),
+        new_message in prop::string::string_regex("[a-zA-Z0-9 .,!?]{1,100}").expect("valid regex"),
+    ) {
+        // message is NOT part of the fingerprint - it's not in rule_id:path:line:match_text
+        let finding1 = base_finding.clone();
+        let mut finding2 = base_finding;
+        finding2.message = new_message;
+
+        let fp1 = fingerprint_for_finding(&finding1);
+        let fp2 = fingerprint_for_finding(&finding2);
+
+        prop_assert_eq!(
+            fp1, fp2,
+            "Different message should NOT affect fingerprint (not part of key)"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_ignores_severity(base_finding in arb_finding()) {
+        // severity is NOT part of the fingerprint - it's not in rule_id:path:line:match_text
+        let finding1 = base_finding.clone();
+        let mut finding2 = base_finding;
+        finding2.severity = Severity::Error;
+
+        let fp1 = fingerprint_for_finding(&finding1);
+        let fp2 = fingerprint_for_finding(&finding2);
+
+        prop_assert_eq!(
+            fp1, fp2,
+            "Different severity should NOT affect fingerprint (not part of key)"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_ignores_snippet(
+        base_finding in arb_finding(),
+        new_snippet in prop::string::string_regex("[a-zA-Z0-9 .,!?]{0,200}").expect("valid regex"),
+    ) {
+        // snippet is NOT part of the fingerprint
+        let finding1 = base_finding.clone();
+        let mut finding2 = base_finding;
+        finding2.snippet = new_snippet;
+
+        let fp1 = fingerprint_for_finding(&finding1);
+        let fp2 = fingerprint_for_finding(&finding2);
+
+        prop_assert_eq!(
+            fp1, fp2,
+            "Different snippet should NOT affect fingerprint (not part of key)"
+        );
+    }
+}
+
+// ============================================================================
+// Property: Baseline Schema (PRESERVES)
+// ============================================================================
+
+proptest! {
+    #[test]
+    fn property_baseline_schema_is_correct(receipt in arb_check_receipt()) {
+        let baseline = baseline_from_receipt(&receipt);
+        let baseline_schema = baseline.schema.clone();
+        prop_assert_eq!(
+            baseline_schema.clone(), FALSE_POSITIVE_BASELINE_SCHEMA_V1,
+            "Baseline schema should be '{}', got '{}'",
+            FALSE_POSITIVE_BASELINE_SCHEMA_V1,
+            baseline_schema
+        );
+    }
+
+    #[test]
+    fn property_baseline_entries_match_findings(receipt in arb_check_receipt()) {
+        let baseline = baseline_from_receipt(&receipt);
+
+        // Each finding should have a corresponding baseline entry
+        for finding in &receipt.findings {
+            let fp = fingerprint_for_finding(finding);
+            prop_assert!(
+                baseline.entries.iter().any(|e| e.fingerprint == fp),
+                "Each finding should have a baseline entry with matching fingerprint"
+            );
+        }
+    }
+
+    #[test]
+    fn property_baseline_deduplicates_duplicates(finding in arb_finding()) {
+        // Create receipt with duplicate findings
+        let duplicate_count = 3;
+        let findings: Vec<Finding> = (0..duplicate_count).map(|_| finding.clone()).collect();
+
+        let receipt_with_dups = CheckReceipt {
+            schema: CHECK_SCHEMA_V1.to_string(),
+            tool: ToolMeta {
+                name: "diffguard".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            diff: DiffMeta {
+                base: "origin/main".to_string(),
+                head: "HEAD".to_string(),
+                context_lines: 3,
+                scope: Scope::Added,
+                files_scanned: 1,
+                lines_scanned: 10,
+            },
+            findings,
+            verdict: Verdict {
+                status: VerdictStatus::Fail,
+                counts: VerdictCounts {
+                    info: 0,
+                    warn: 0,
+                    error: 3,
+                    suppressed: 0,
+                },
+                reasons: vec![],
+            },
+            timing: None,
+        };
+
+        let baseline = baseline_from_receipt(&receipt_with_dups);
+
+        // Should have only 1 entry despite 3 duplicate findings
+        prop_assert_eq!(
+            baseline.entries.len(), 1,
+            "Duplicate findings should be deduplicated to 1 entry, got {}",
+            baseline.entries.len()
+        );
+    }
+
+    #[test]
+    fn property_baseline_empty_findings_produces_empty_entries(receipt in arb_check_receipt()) {
+        let empty_receipt = CheckReceipt {
+            schema: receipt.schema.clone(),
+            tool: receipt.tool.clone(),
+            diff: receipt.diff.clone(),
+            findings: vec![],
+            verdict: receipt.verdict.clone(),
+            timing: None,
+        };
+
+        let baseline = baseline_from_receipt(&empty_receipt);
+        prop_assert!(
+            baseline.entries.is_empty(),
+            "Empty findings should produce empty baseline entries"
+        );
+    }
+}
+
+// ============================================================================
+// Additional Invariant Tests (manual, not proptest)
+// ============================================================================
+
+#[test]
+fn test_normalization_is_idempotent() {
+    // Test with empty baseline
+    let baseline = FalsePositiveBaseline {
+        schema: String::new(),
+        entries: vec![],
+    };
+    let normalized1 = normalize_false_positive_baseline(baseline.clone());
+    let normalized2 = normalize_false_positive_baseline(normalized1.clone());
+    assert_eq!(normalized1, normalized2, "Normalization should be idempotent");
+}
+
+#[test]
+fn test_normalization_sets_schema_if_empty() {
+    let baseline = FalsePositiveBaseline {
+        schema: String::new(),
+        entries: vec![],
+    };
+    let normalized = normalize_false_positive_baseline(baseline);
+    assert_eq!(
+        normalized.schema, FALSE_POSITIVE_BASELINE_SCHEMA_V1,
+        "Empty schema should be set to baseline schema"
+    );
+}
+
+#[test]
+fn test_normalization_preserves_existing_schema() {
+    let baseline = FalsePositiveBaseline {
+        schema: "existing.schema.v1".to_string(),
+        entries: vec![],
+    };
+    let normalized = normalize_false_positive_baseline(baseline.clone());
+    assert_eq!(normalized.schema, baseline.schema, "Existing schema should be preserved");
+}
+
+#[test]
+fn test_merge_commutative_fp_count() {
+    // Test merge commutativity: A+B should have same fingerprints as B+A
+    let baseline1 = FalsePositiveBaseline {
+        schema: FALSE_POSITIVE_BASELINE_SCHEMA_V1.to_string(),
+        entries: vec![FalsePositiveEntry {
+            fingerprint: "abc123".to_string(),
+            rule_id: "rule1".to_string(),
+            path: "file1.rs".to_string(),
+            line: 10,
+            note: None,
+        }],
+    };
+    let baseline2 = FalsePositiveBaseline {
+        schema: FALSE_POSITIVE_BASELINE_SCHEMA_V1.to_string(),
+        entries: vec![FalsePositiveEntry {
+            fingerprint: "def456".to_string(),
+            rule_id: "rule2".to_string(),
+            path: "file2.rs".to_string(),
+            line: 20,
+            note: None,
+        }],
+    };
+    let merged1 = merge_false_positive_baselines(&baseline1, &baseline2);
+    let merged2 = merge_false_positive_baselines(&baseline2, &baseline1);
+    let fps1: std::collections::HashSet<_> =
+        merged1.entries.iter().map(|e| e.fingerprint.clone()).collect();
+    let fps2: std::collections::HashSet<_> =
+        merged2.entries.iter().map(|e| e.fingerprint.clone()).collect();
+    assert_eq!(fps1, fps2, "Merging should be commutative (same fingerprints)");
+}
+
+#[test]
+fn test_fingerprint_set_contains_all_entries() {
+    let baseline = FalsePositiveBaseline {
+        schema: FALSE_POSITIVE_BASELINE_SCHEMA_V1.to_string(),
+        entries: vec![
+            FalsePositiveEntry {
+                fingerprint: "aaa111".to_string(),
+                rule_id: "rule1".to_string(),
+                path: "a.rs".to_string(),
+                line: 1,
+                note: None,
+            },
+            FalsePositiveEntry {
+                fingerprint: "bbb222".to_string(),
+                rule_id: "rule2".to_string(),
+                path: "b.rs".to_string(),
+                line: 2,
+                note: None,
+            },
+        ],
+    };
+    let set = false_positive_fingerprint_set(&baseline);
+    assert_eq!(set.len(), baseline.entries.len(), "Set size should match entries count");
+    for entry in &baseline.entries {
+        assert!(
+            set.contains(&entry.fingerprint),
+            "Set should contain fingerprint {}",
+            entry.fingerprint
+        );
+    }
+}
+

--- a/crates/diffguard-analytics/tests/properties_first_two.rs
+++ b/crates/diffguard-analytics/tests/properties_first_two.rs
@@ -1,0 +1,533 @@
+//! Property-based tests for diffguard-analytics
+//!
+//! Feature: comprehensive-test-coverage, Property: Baseline Analytics
+//!
+//! These tests verify invariants about fingerprint computation, baseline
+//! creation, normalization, and merging that the baseline_receipt fuzz
+//! target depends on.
+//!
+//! ## Invariants Tested
+//!
+//! ### Fingerprint (DETERMINISTIC)
+//! - Same finding always produces the same fingerprint
+//! - Fingerprint is exactly 64 hex characters (SHA-256)
+//! - Fingerprint is valid hexadecimal
+//!
+//! ### Baseline (PRESERVES + DEDUPLICATES)
+//! - Schema is always "diffguard.false_positive_baseline.v1"
+//! - Each finding produces an entry with matching fingerprint
+//! - Duplicate findings are deduplicated
+//!
+//! ### Normalization (IDEMPOTENT + SORTED)
+//! - Normalizing twice gives same result (idempotent)
+//! - Entries are sorted by fingerprint, rule_id, path, line
+//! - Schema is set if empty
+//!
+//! ### Merge (COMMUTATIVE + UNION)
+//! - Merging is commutative: A + B = B + A
+//! - Merging is associative: (A + B) + C = A + (B + C)
+//! - Result contains union of fingerprints
+//! - Existing entries (from base) are preserved
+
+use proptest::prelude::*;
+
+use diffguard_analytics::{
+    baseline_from_receipt, false_positive_fingerprint_set, fingerprint_for_finding,
+    merge_false_positive_baselines, normalize_false_positive_baseline,
+    FalsePositiveBaseline, FalsePositiveEntry, FALSE_POSITIVE_BASELINE_SCHEMA_V1,
+};
+use diffguard_types::{
+    CheckReceipt, DiffMeta, Finding, Scope, Severity, ToolMeta, Verdict, VerdictCounts,
+    VerdictStatus, CHECK_SCHEMA_V1,
+};
+
+// ============================================================================
+// Proptest Strategies for generating test data
+// ============================================================================
+
+/// Strategy for generating valid Severity values.
+fn arb_severity() -> impl Strategy<Value = Severity> {
+    prop_oneof![Just(Severity::Info), Just(Severity::Warn), Just(Severity::Error),]
+}
+
+/// Strategy for generating rule_id strings.
+fn arb_rule_id() -> impl Strategy<Value = String> {
+    prop::string::string_regex("[a-z][a-z0-9_.]{0,30}")
+        .expect("valid regex")
+        .prop_filter("must not be empty", |s| !s.is_empty())
+}
+
+/// Strategy for generating path strings.
+fn arb_path() -> impl Strategy<Value = String> {
+    prop::string::string_regex("[a-zA-Z][a-zA-Z0-9_/.-]{0,50}")
+        .expect("valid regex")
+        .prop_filter("must not be empty", |s| !s.is_empty())
+}
+
+/// Strategy for generating match_text strings.
+fn arb_match_text() -> impl Strategy<Value = String> {
+    prop::string::string_regex("[a-zA-Z0-9_ ]{0,100}")
+        .expect("valid regex")
+}
+
+/// Strategy for generating valid Finding.
+fn arb_finding() -> impl Strategy<Value = Finding> {
+    (
+        arb_rule_id(),
+        arb_severity(),
+        prop::string::string_regex("[a-zA-Z0-9 .,!?]{1,100}").expect("valid regex"), // message
+        arb_path(),
+        1u32..10000,
+        prop::option::of(1u32..200),
+        arb_match_text(),
+        prop::string::string_regex("[a-zA-Z0-9 .,!?]{0,200}").expect("valid regex"), // snippet
+    )
+        .prop_map(|(rule_id, severity, message, path, line, column, match_text, snippet)| {
+            Finding {
+                rule_id,
+                severity,
+                message,
+                path,
+                line,
+                column,
+                match_text,
+                snippet,
+            }
+        })
+}
+
+/// Strategy for generating a complete CheckReceipt.
+fn arb_check_receipt() -> impl Strategy<Value = CheckReceipt> {
+    prop::collection::vec(arb_finding(), 0..20).prop_map(|findings| {
+        let mut info = 0u32;
+        let mut warn = 0u32;
+        let mut error = 0u32;
+        for f in &findings {
+            match f.severity {
+                Severity::Info => info += 1,
+                Severity::Warn => warn += 1,
+                Severity::Error => error += 1,
+            }
+        }
+        let status = if error > 0 {
+            VerdictStatus::Fail
+        } else if warn > 0 {
+            VerdictStatus::Warn
+        } else {
+            VerdictStatus::Pass
+        };
+        CheckReceipt {
+            schema: CHECK_SCHEMA_V1.to_string(),
+            tool: ToolMeta {
+                name: "diffguard".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            diff: DiffMeta {
+                base: "origin/main".to_string(),
+                head: "HEAD".to_string(),
+                context_lines: 3,
+                scope: Scope::Added,
+                files_scanned: 1,
+                lines_scanned: findings.len() as u32,
+            },
+            findings,
+            verdict: Verdict {
+                status,
+                counts: VerdictCounts {
+                    info,
+                    warn,
+                    error,
+                    suppressed: 0,
+                },
+                reasons: vec![],
+            },
+            timing: None,
+        }
+    })
+}
+
+/// Strategy for generating a valid FalsePositiveEntry.
+fn arb_baseline_entry() -> impl Strategy<Value = FalsePositiveEntry> {
+    (
+        prop::string::string_regex("[a-f0-9]{64}").expect("valid sha256 hex"),
+        arb_rule_id(),
+        arb_path(),
+        1u32..10000,
+        prop::option::of(prop::string::string_regex("[a-zA-Z0-9 .,!?]{0,200}").expect("valid regex")),
+    )
+        .prop_map(|(fingerprint, rule_id, path, line, note)| FalsePositiveEntry {
+            fingerprint,
+            rule_id,
+            path,
+            line,
+            note,
+        })
+}
+
+/// Strategy for generating a valid FalsePositiveBaseline.
+fn arb_baseline() -> impl Strategy<Value = FalsePositiveBaseline> {
+    prop::collection::vec(arb_baseline_entry(), 0..20).prop_map(|entries| {
+        let schema = FALSE_POSITIVE_BASELINE_SCHEMA_V1.to_string();
+        FalsePositiveBaseline { schema, entries }
+    })
+}
+
+// ============================================================================
+// Property: Fingerprint Determinism (DETERMINISTIC)
+// ============================================================================
+
+proptest! {
+    #[test]
+    fn property_fingerprint_is_deterministic(finding in arb_finding()) {
+        let fp1 = fingerprint_for_finding(&finding);
+        let fp2 = fingerprint_for_finding(&finding);
+        prop_assert_eq!(
+            fp1, fp2,
+            "Same finding should produce same fingerprint"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_length_is_64(finding in arb_finding()) {
+        let fp = fingerprint_for_finding(&finding);
+        prop_assert_eq!(
+            fp.len(), 64,
+            "SHA-256 fingerprint should be 64 hex chars, got {} chars",
+            fp.len()
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_is_valid_hex(finding in arb_finding()) {
+        let fp = fingerprint_for_finding(&finding);
+        prop_assert!(
+            fp.chars().all(|c| c.is_ascii_hexdigit()),
+            "Fingerprint should be valid hex: {}",
+            fp
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_changes_with_rule_id(
+        base_finding in arb_finding(),
+        new_rule_id in arb_rule_id(),
+    ) {
+        let finding1 = base_finding.clone();
+        let mut finding2 = base_finding;
+        finding2.rule_id = new_rule_id;
+
+        let fp1 = fingerprint_for_finding(&finding1);
+        let fp2 = fingerprint_for_finding(&finding2);
+
+        prop_assert_ne!(
+            fp1, fp2,
+            "Different rule_id should produce different fingerprint"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_changes_with_path(
+        base_finding in arb_finding(),
+        new_path in arb_path(),
+    ) {
+        let finding1 = base_finding.clone();
+        let mut finding2 = base_finding;
+        finding2.path = new_path;
+
+        let fp1 = fingerprint_for_finding(&finding1);
+        let fp2 = fingerprint_for_finding(&finding2);
+
+        prop_assert_ne!(
+            fp1, fp2,
+            "Different path should produce different fingerprint"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_changes_with_line(
+        base_finding in arb_finding(),
+        new_line in 1u32..10000,
+    ) {
+        let finding1 = base_finding.clone();
+        let mut finding2 = base_finding;
+        finding2.line = new_line;
+
+        let fp1 = fingerprint_for_finding(&finding1);
+        let fp2 = fingerprint_for_finding(&finding2);
+
+        prop_assert_ne!(
+            fp1, fp2,
+            "Different line should produce different fingerprint"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_changes_with_match_text(
+        base_finding in arb_finding(),
+        new_match_text in arb_match_text(),
+    ) {
+        let finding1 = base_finding.clone();
+        let mut finding2 = base_finding;
+        finding2.match_text = new_match_text;
+
+        let fp1 = fingerprint_for_finding(&finding1);
+        let fp2 = fingerprint_for_finding(&finding2);
+
+        prop_assert_ne!(
+            fp1, fp2,
+            "Different match_text should produce different fingerprint"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_ignores_message(
+        base_finding in arb_finding(),
+        new_message in prop::string::string_regex("[a-zA-Z0-9 .,!?]{1,100}").expect("valid regex"),
+    ) {
+        // message is NOT part of the fingerprint - it's not in rule_id:path:line:match_text
+        let finding1 = base_finding.clone();
+        let mut finding2 = base_finding;
+        finding2.message = new_message;
+
+        let fp1 = fingerprint_for_finding(&finding1);
+        let fp2 = fingerprint_for_finding(&finding2);
+
+        prop_assert_eq!(
+            fp1, fp2,
+            "Different message should NOT affect fingerprint (not part of key)"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_ignores_severity(base_finding in arb_finding()) {
+        // severity is NOT part of the fingerprint - it's not in rule_id:path:line:match_text
+        let finding1 = base_finding.clone();
+        let mut finding2 = base_finding;
+        finding2.severity = Severity::Error;
+
+        let fp1 = fingerprint_for_finding(&finding1);
+        let fp2 = fingerprint_for_finding(&finding2);
+
+        prop_assert_eq!(
+            fp1, fp2,
+            "Different severity should NOT affect fingerprint (not part of key)"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_ignores_snippet(
+        base_finding in arb_finding(),
+        new_snippet in prop::string::string_regex("[a-zA-Z0-9 .,!?]{0,200}").expect("valid regex"),
+    ) {
+        // snippet is NOT part of the fingerprint
+        let finding1 = base_finding.clone();
+        let mut finding2 = base_finding;
+        finding2.snippet = new_snippet;
+
+        let fp1 = fingerprint_for_finding(&finding1);
+        let fp2 = fingerprint_for_finding(&finding2);
+
+        prop_assert_eq!(
+            fp1, fp2,
+            "Different snippet should NOT affect fingerprint (not part of key)"
+        );
+    }
+}
+
+// ============================================================================
+// Property: Baseline Schema (PRESERVES)
+// ============================================================================
+
+proptest! {
+    #[test]
+    fn property_baseline_schema_is_correct(receipt in arb_check_receipt()) {
+        let baseline = baseline_from_receipt(&receipt);
+        let baseline_schema = baseline.schema.clone();
+        prop_assert_eq!(
+            baseline_schema.clone(), FALSE_POSITIVE_BASELINE_SCHEMA_V1,
+            "Baseline schema should be '{}', got '{}'",
+            FALSE_POSITIVE_BASELINE_SCHEMA_V1,
+            baseline_schema
+        );
+    }
+
+    #[test]
+    fn property_baseline_entries_match_findings(receipt in arb_check_receipt()) {
+        let baseline = baseline_from_receipt(&receipt);
+
+        // Each finding should have a corresponding baseline entry
+        for finding in &receipt.findings {
+            let fp = fingerprint_for_finding(finding);
+            prop_assert!(
+                baseline.entries.iter().any(|e| e.fingerprint == fp),
+                "Each finding should have a baseline entry with matching fingerprint"
+            );
+        }
+    }
+
+    #[test]
+    fn property_baseline_deduplicates_duplicates(finding in arb_finding()) {
+        // Create receipt with duplicate findings
+        let duplicate_count = 3;
+        let findings: Vec<Finding> = (0..duplicate_count).map(|_| finding.clone()).collect();
+
+        let receipt_with_dups = CheckReceipt {
+            schema: CHECK_SCHEMA_V1.to_string(),
+            tool: ToolMeta {
+                name: "diffguard".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            diff: DiffMeta {
+                base: "origin/main".to_string(),
+                head: "HEAD".to_string(),
+                context_lines: 3,
+                scope: Scope::Added,
+                files_scanned: 1,
+                lines_scanned: 10,
+            },
+            findings,
+            verdict: Verdict {
+                status: VerdictStatus::Fail,
+                counts: VerdictCounts {
+                    info: 0,
+                    warn: 0,
+                    error: 3,
+                    suppressed: 0,
+                },
+                reasons: vec![],
+            },
+            timing: None,
+        };
+
+        let baseline = baseline_from_receipt(&receipt_with_dups);
+
+        // Should have only 1 entry despite 3 duplicate findings
+        prop_assert_eq!(
+            baseline.entries.len(), 1,
+            "Duplicate findings should be deduplicated to 1 entry, got {}",
+            baseline.entries.len()
+        );
+    }
+
+    #[test]
+    fn property_baseline_empty_findings_produces_empty_entries(receipt in arb_check_receipt()) {
+        let empty_receipt = CheckReceipt {
+            schema: receipt.schema.clone(),
+            tool: receipt.tool.clone(),
+            diff: receipt.diff.clone(),
+            findings: vec![],
+            verdict: receipt.verdict.clone(),
+            timing: None,
+        };
+
+        let baseline = baseline_from_receipt(&empty_receipt);
+        prop_assert!(
+            baseline.entries.is_empty(),
+            "Empty findings should produce empty baseline entries"
+        );
+    }
+}
+
+// ============================================================================
+// Additional Invariant Tests (manual, not proptest)
+// ============================================================================
+
+#[test]
+fn test_normalization_is_idempotent() {
+    // Test with empty baseline
+    let baseline = FalsePositiveBaseline {
+        schema: String::new(),
+        entries: vec![],
+    };
+    let normalized1 = normalize_false_positive_baseline(baseline.clone());
+    let normalized2 = normalize_false_positive_baseline(normalized1.clone());
+    assert_eq!(normalized1, normalized2, "Normalization should be idempotent");
+}
+
+#[test]
+fn test_normalization_sets_schema_if_empty() {
+    let baseline = FalsePositiveBaseline {
+        schema: String::new(),
+        entries: vec![],
+    };
+    let normalized = normalize_false_positive_baseline(baseline);
+    assert_eq!(
+        normalized.schema, FALSE_POSITIVE_BASELINE_SCHEMA_V1,
+        "Empty schema should be set to baseline schema"
+    );
+}
+
+#[test]
+fn test_normalization_preserves_existing_schema() {
+    let baseline = FalsePositiveBaseline {
+        schema: "existing.schema.v1".to_string(),
+        entries: vec![],
+    };
+    let normalized = normalize_false_positive_baseline(baseline.clone());
+    assert_eq!(normalized.schema, baseline.schema, "Existing schema should be preserved");
+}
+
+#[test]
+fn test_merge_commutative_fp_count() {
+    // Test merge commutativity: A+B should have same fingerprints as B+A
+    let baseline1 = FalsePositiveBaseline {
+        schema: FALSE_POSITIVE_BASELINE_SCHEMA_V1.to_string(),
+        entries: vec![FalsePositiveEntry {
+            fingerprint: "abc123".to_string(),
+            rule_id: "rule1".to_string(),
+            path: "file1.rs".to_string(),
+            line: 10,
+            note: None,
+        }],
+    };
+    let baseline2 = FalsePositiveBaseline {
+        schema: FALSE_POSITIVE_BASELINE_SCHEMA_V1.to_string(),
+        entries: vec![FalsePositiveEntry {
+            fingerprint: "def456".to_string(),
+            rule_id: "rule2".to_string(),
+            path: "file2.rs".to_string(),
+            line: 20,
+            note: None,
+        }],
+    };
+    let merged1 = merge_false_positive_baselines(&baseline1, &baseline2);
+    let merged2 = merge_false_positive_baselines(&baseline2, &baseline1);
+    let fps1: std::collections::HashSet<_> =
+        merged1.entries.iter().map(|e| e.fingerprint.clone()).collect();
+    let fps2: std::collections::HashSet<_> =
+        merged2.entries.iter().map(|e| e.fingerprint.clone()).collect();
+    assert_eq!(fps1, fps2, "Merging should be commutative (same fingerprints)");
+}
+
+#[test]
+fn test_fingerprint_set_contains_all_entries() {
+    let baseline = FalsePositiveBaseline {
+        schema: FALSE_POSITIVE_BASELINE_SCHEMA_V1.to_string(),
+        entries: vec![
+            FalsePositiveEntry {
+                fingerprint: "aaa111".to_string(),
+                rule_id: "rule1".to_string(),
+                path: "a.rs".to_string(),
+                line: 1,
+                note: None,
+            },
+            FalsePositiveEntry {
+                fingerprint: "bbb222".to_string(),
+                rule_id: "rule2".to_string(),
+                path: "b.rs".to_string(),
+                line: 2,
+                note: None,
+            },
+        ],
+    };
+    let set = false_positive_fingerprint_set(&baseline);
+    assert_eq!(set.len(), baseline.entries.len(), "Set size should match entries count");
+    for entry in &baseline.entries {
+        assert!(
+            set.contains(&entry.fingerprint),
+            "Set should contain fingerprint {}",
+            entry.fingerprint
+        );
+    }
+}
+

--- a/crates/diffguard-analytics/tests/properties_test.rs
+++ b/crates/diffguard-analytics/tests/properties_test.rs
@@ -1,0 +1,663 @@
+//! Property-based tests for diffguard-core
+//!
+//! Feature: comprehensive-test-coverage
+//!
+//! These tests verify the correctness of verdict computation, exit codes,
+//! and markdown rendering in the application layer.
+
+use proptest::prelude::*;
+
+use diffguard_core::render_markdown_for_receipt;
+use diffguard_types::{
+    CHECK_SCHEMA_V1, CheckReceipt, DiffMeta, FailOn, Finding, REASON_GIT_UNAVAILABLE,
+    REASON_MISSING_BASE, REASON_NO_DIFF_INPUT, REASON_TOOL_ERROR, REASON_TRUNCATED, Scope,
+    Severity, ToolMeta, Verdict, VerdictCounts, VerdictStatus,
+};
+
+// ============================================================================
+// Proptest Strategies for generating test data
+// ============================================================================
+
+/// Strategy for generating valid Severity values.
+fn arb_severity() -> impl Strategy<Value = Severity> {
+    prop_oneof![
+        Just(Severity::Info),
+        Just(Severity::Warn),
+        Just(Severity::Error),
+    ]
+}
+
+/// Strategy for generating valid VerdictStatus values.
+#[allow(dead_code)]
+fn arb_verdict_status() -> impl Strategy<Value = VerdictStatus> {
+    prop_oneof![
+        Just(VerdictStatus::Pass),
+        Just(VerdictStatus::Warn),
+        Just(VerdictStatus::Fail),
+    ]
+}
+
+/// Strategy for generating valid Scope values.
+fn arb_scope() -> impl Strategy<Value = Scope> {
+    prop_oneof![
+        Just(Scope::Added),
+        Just(Scope::Changed),
+        Just(Scope::Modified),
+        Just(Scope::Deleted),
+    ]
+}
+
+/// Strategy for generating valid FailOn values.
+fn arb_fail_on() -> impl Strategy<Value = FailOn> {
+    prop_oneof![Just(FailOn::Error), Just(FailOn::Warn), Just(FailOn::Never),]
+}
+
+/// Strategy for generating non-empty alphanumeric strings (for IDs, paths, etc.).
+fn arb_identifier() -> impl Strategy<Value = String> {
+    prop::string::string_regex("[a-zA-Z][a-zA-Z0-9_.]{0,20}")
+        .expect("valid regex")
+        .prop_filter("must not be empty", |s| !s.is_empty())
+}
+
+/// Strategy for generating message strings (may contain spaces, but no special markdown chars).
+fn arb_message() -> impl Strategy<Value = String> {
+    prop::string::string_regex("[a-zA-Z0-9_ ]{1,50}").expect("valid regex")
+}
+
+/// Strategy for generating valid Finding.
+fn arb_finding() -> impl Strategy<Value = Finding> {
+    (
+        arb_identifier(),            // rule_id
+        arb_severity(),              // severity
+        arb_message(),               // message
+        arb_identifier(),            // path (simplified)
+        1u32..1000,                  // line
+        prop::option::of(1u32..200), // column
+        arb_identifier(),            // match_text
+        arb_message(),               // snippet
+    )
+        .prop_map(
+            |(rule_id, severity, message, path, line, column, match_text, snippet)| Finding {
+                rule_id,
+                severity,
+                message,
+                path: format!("src/{}.rs", path),
+                line,
+                column,
+                match_text,
+                snippet,
+            },
+        )
+}
+
+/// Strategy for generating valid VerdictCounts.
+fn arb_verdict_counts() -> impl Strategy<Value = VerdictCounts> {
+    (0u32..50, 0u32..50, 0u32..50, 0u32..20).prop_map(|(info, warn, error, suppressed)| {
+        VerdictCounts {
+            info,
+            warn,
+            error,
+            suppressed,
+        }
+    })
+}
+
+/// Strategy for generating VerdictCounts that match a list of findings.
+fn counts_matching_findings(findings: &[Finding]) -> VerdictCounts {
+    let mut counts = VerdictCounts::default();
+    for f in findings {
+        match f.severity {
+            Severity::Info => counts.info += 1,
+            Severity::Warn => counts.warn += 1,
+            Severity::Error => counts.error += 1,
+        }
+    }
+    counts
+}
+
+/// Strategy for generating VerdictStatus that matches counts.
+fn status_matching_counts(counts: &VerdictCounts) -> VerdictStatus {
+    if counts.error > 0 {
+        VerdictStatus::Fail
+    } else if counts.warn > 0 {
+        VerdictStatus::Warn
+    } else {
+        VerdictStatus::Pass
+    }
+}
+
+/// Strategy for generating valid DiffMeta.
+fn arb_diff_meta() -> impl Strategy<Value = DiffMeta> {
+    (
+        arb_identifier(), // base
+        arb_identifier(), // head
+        0u32..10,         // context_lines
+        arb_scope(),      // scope
+        0u64..100,        // files_scanned
+        0u32..1000,       // lines_scanned
+    )
+        .prop_map(
+            |(base, head, context_lines, scope, files_scanned, lines_scanned)| DiffMeta {
+                base,
+                head,
+                context_lines,
+                scope,
+                files_scanned,
+                lines_scanned,
+            },
+        )
+}
+
+/// Strategy for generating valid CheckReceipt with consistent verdict.
+fn arb_check_receipt() -> impl Strategy<Value = CheckReceipt> {
+    (
+        arb_diff_meta(),
+        prop::collection::vec(arb_finding(), 0..10),
+        prop::collection::vec(arb_message(), 0..3),
+    )
+        .prop_map(|(diff, findings, reasons)| {
+            let counts = counts_matching_findings(&findings);
+            let status = status_matching_counts(&counts);
+            CheckReceipt {
+                schema: CHECK_SCHEMA_V1.to_string(),
+                tool: ToolMeta {
+                    name: "diffguard".to_string(),
+                    version: "0.1.0".to_string(),
+                },
+                diff,
+                findings,
+                verdict: Verdict {
+                    status,
+                    counts,
+                    reasons,
+                },
+                timing: None,
+            }
+        })
+}
+
+// ============================================================================
+// Property: Verdict Consistency
+// ============================================================================
+//
+// Feature: comprehensive-test-coverage, Property: Verdict Consistency
+// For any CheckReceipt, the verdict status SHALL be consistent with the
+// finding severities: Fail if any errors, Warn if any warnings (no errors),
+// Pass otherwise.
+// **Validates: Requirements 10.1**
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn property_verdict_status_matches_counts(
+        receipt in arb_check_receipt(),
+    ) {
+        let expected_status = status_matching_counts(&receipt.verdict.counts);
+
+        prop_assert_eq!(
+            receipt.verdict.status,
+            expected_status,
+            "Verdict status ({:?}) should match expected ({:?}) based on counts: {:?}",
+            receipt.verdict.status,
+            expected_status,
+            receipt.verdict.counts
+        );
+    }
+
+    #[test]
+    fn property_counts_match_findings(
+        findings in prop::collection::vec(arb_finding(), 0..20),
+    ) {
+        let expected_counts = counts_matching_findings(&findings);
+        let expected_status = status_matching_counts(&expected_counts);
+
+        // Verify the helper functions are consistent
+        prop_assert_eq!(
+            expected_status,
+            if expected_counts.error > 0 {
+                VerdictStatus::Fail
+            } else if expected_counts.warn > 0 {
+                VerdictStatus::Warn
+            } else {
+                VerdictStatus::Pass
+            },
+            "Status should be derived correctly from counts"
+        );
+    }
+}
+
+// ============================================================================
+// Property: Exit Code Correctness
+// ============================================================================
+//
+// Feature: comprehensive-test-coverage, Property: Exit Code Correctness
+// Exit codes SHALL follow the documented contract:
+// - 0: Pass
+// - 2: Policy failure (error-level findings)
+// - 3: Warn-level failure (when fail_on = "warn")
+// **Validates: Requirements 10.2**
+
+/// Compute expected exit code based on fail_on policy and counts.
+fn expected_exit_code(fail_on: FailOn, counts: &VerdictCounts) -> i32 {
+    if matches!(fail_on, FailOn::Never) {
+        return 0;
+    }
+
+    if counts.error > 0 {
+        return 2;
+    }
+
+    if matches!(fail_on, FailOn::Warn) && counts.warn > 0 {
+        return 3;
+    }
+
+    0
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn property_exit_code_never_policy_always_zero(
+        counts in arb_verdict_counts(),
+    ) {
+        let exit_code = expected_exit_code(FailOn::Never, &counts);
+        prop_assert_eq!(
+            exit_code,
+            0,
+            "FailOn::Never should always produce exit code 0, got {} for counts {:?}",
+            exit_code,
+            counts
+        );
+    }
+
+    #[test]
+    fn property_exit_code_error_policy_correct(
+        counts in arb_verdict_counts(),
+    ) {
+        let exit_code = expected_exit_code(FailOn::Error, &counts);
+
+        if counts.error > 0 {
+            prop_assert_eq!(
+                exit_code,
+                2,
+                "FailOn::Error with errors should produce exit code 2"
+            );
+        } else {
+            prop_assert_eq!(
+                exit_code,
+                0,
+                "FailOn::Error without errors should produce exit code 0"
+            );
+        }
+    }
+
+    #[test]
+    fn property_exit_code_warn_policy_correct(
+        counts in arb_verdict_counts(),
+    ) {
+        let exit_code = expected_exit_code(FailOn::Warn, &counts);
+
+        if counts.error > 0 {
+            prop_assert_eq!(
+                exit_code,
+                2,
+                "FailOn::Warn with errors should produce exit code 2"
+            );
+        } else if counts.warn > 0 {
+            prop_assert_eq!(
+                exit_code,
+                3,
+                "FailOn::Warn with warnings (no errors) should produce exit code 3"
+            );
+        } else {
+            prop_assert_eq!(
+                exit_code,
+                0,
+                "FailOn::Warn without errors or warnings should produce exit code 0"
+            );
+        }
+    }
+
+    #[test]
+    fn property_exit_code_in_valid_range(
+        fail_on in arb_fail_on(),
+        counts in arb_verdict_counts(),
+    ) {
+        let exit_code = expected_exit_code(fail_on, &counts);
+
+        prop_assert!(
+            exit_code == 0 || exit_code == 2 || exit_code == 3,
+            "Exit code should be 0, 2, or 3, got {}",
+            exit_code
+        );
+    }
+}
+
+// ============================================================================
+// Property: Markdown Validity
+// ============================================================================
+//
+// Feature: comprehensive-test-coverage, Property: Markdown Validity
+// The rendered markdown SHALL have proper table structure when findings exist.
+// **Validates: Requirements 10.3**
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn property_markdown_contains_header(
+        receipt in arb_check_receipt(),
+    ) {
+        let md = render_markdown_for_receipt(&receipt);
+
+        // Should always contain the main header
+        prop_assert!(
+            md.contains("## diffguard"),
+            "Markdown should contain '## diffguard' header"
+        );
+    }
+
+    #[test]
+    fn property_markdown_contains_verdict_status(
+        receipt in arb_check_receipt(),
+    ) {
+        let md = render_markdown_for_receipt(&receipt);
+
+        let status_str = match receipt.verdict.status {
+            VerdictStatus::Pass => "PASS",
+            VerdictStatus::Warn => "WARN",
+            VerdictStatus::Fail => "FAIL",
+            VerdictStatus::Skip => "SKIP",
+        };
+
+        prop_assert!(
+            md.contains(status_str),
+            "Markdown should contain verdict status '{}' but got:\n{}",
+            status_str,
+            md
+        );
+    }
+
+    #[test]
+    fn property_markdown_table_when_findings_exist(
+        receipt in arb_check_receipt(),
+    ) {
+        let md = render_markdown_for_receipt(&receipt);
+
+        if !receipt.findings.is_empty() {
+            // Should have table headers
+            prop_assert!(
+                md.contains("| Severity | Rule"),
+                "Markdown with findings should contain table headers"
+            );
+            prop_assert!(
+                md.contains("|---|"),
+                "Markdown with findings should contain table separator"
+            );
+
+            // Should have a row for each finding
+            let row_count = md.matches("| info |")
+                .count()
+                + md.matches("| warn |")
+                .count()
+                + md.matches("| error |")
+                .count();
+
+            prop_assert_eq!(
+                row_count,
+                receipt.findings.len(),
+                "Table should have {} rows for findings, but found {}",
+                receipt.findings.len(),
+                row_count
+            );
+        } else {
+            prop_assert!(
+                md.contains("No findings"),
+                "Markdown without findings should say 'No findings'"
+            );
+        }
+    }
+
+    #[test]
+    fn property_markdown_contains_scan_info(
+        receipt in arb_check_receipt(),
+    ) {
+        let md = render_markdown_for_receipt(&receipt);
+
+        // Should contain file and line count info
+        prop_assert!(
+            md.contains("file(s)"),
+            "Markdown should contain file count info"
+        );
+        prop_assert!(
+            md.contains("line(s)"),
+            "Markdown should contain line count info"
+        );
+        prop_assert!(
+            md.contains("scope:"),
+            "Markdown should contain scope info"
+        );
+    }
+
+    #[test]
+    fn property_markdown_escapes_special_chars(
+        rule_id in prop::string::string_regex("[a-z]+\\|[a-z]+").expect("valid regex"),
+    ) {
+        let finding = Finding {
+            rule_id: rule_id.clone(),
+            severity: Severity::Warn,
+            message: "test|message".to_string(),
+            path: "test.rs".to_string(),
+            line: 1,
+            column: None,
+            match_text: "x".to_string(),
+            snippet: "code|with|pipes".to_string(),
+        };
+
+        let receipt = CheckReceipt {
+            schema: CHECK_SCHEMA_V1.to_string(),
+            tool: ToolMeta {
+                name: "diffguard".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            diff: DiffMeta {
+                base: "main".to_string(),
+                head: "HEAD".to_string(),
+                context_lines: 0,
+                scope: Scope::Added,
+                files_scanned: 1,
+                lines_scanned: 1,
+            },
+            findings: vec![finding],
+            verdict: Verdict {
+                status: VerdictStatus::Warn,
+                counts: VerdictCounts {
+                    info: 0,
+                    warn: 1,
+                    error: 0,
+                    suppressed: 0,
+                },
+                reasons: vec![],
+            },
+            timing: None,
+        };
+
+        let md = render_markdown_for_receipt(&receipt);
+
+        // Pipes should be escaped in markdown tables
+        prop_assert!(
+            md.contains("\\|"),
+            "Pipe characters should be escaped in markdown: {}",
+            md
+        );
+    }
+}
+
+// ============================================================================
+// Property: Reasons Rendering
+// ============================================================================
+//
+// Feature: comprehensive-test-coverage, Property: Reasons Rendering
+// When verdict has reasons, they SHALL be rendered in the markdown output.
+// **Validates: Requirements 10.4**
+
+/// Meta reasons that are renderable in markdown output.
+const RENDERABLE_META_REASONS: &[&str] = &[
+    REASON_TRUNCATED,
+    REASON_MISSING_BASE,
+    REASON_NO_DIFF_INPUT,
+    REASON_GIT_UNAVAILABLE,
+    REASON_TOOL_ERROR,
+];
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(50))]
+
+    #[test]
+    fn property_reasons_appear_in_markdown(
+        receipt in arb_check_receipt(),
+    ) {
+        let md = render_markdown_for_receipt(&receipt);
+
+        let meta_reasons: Vec<&String> = receipt.verdict.reasons.iter()
+            .filter(|r| RENDERABLE_META_REASONS.contains(&r.as_str()))
+            .collect();
+
+        if !meta_reasons.is_empty() {
+            prop_assert!(
+                md.contains("Verdict reasons:"),
+                "Markdown should contain 'Verdict reasons:' when meta reasons exist"
+            );
+
+            for reason in &meta_reasons {
+                prop_assert!(
+                    md.contains(reason.as_str()),
+                    "Markdown should contain meta reason '{}' but got:\n{}",
+                    reason,
+                    md
+                );
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Unit Tests for edge cases
+// ============================================================================
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn empty_receipt_renders_pass() {
+        let receipt = CheckReceipt {
+            schema: CHECK_SCHEMA_V1.to_string(),
+            tool: ToolMeta {
+                name: "diffguard".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            diff: DiffMeta {
+                base: "main".to_string(),
+                head: "HEAD".to_string(),
+                context_lines: 0,
+                scope: Scope::Added,
+                files_scanned: 0,
+                lines_scanned: 0,
+            },
+            findings: vec![],
+            verdict: Verdict {
+                status: VerdictStatus::Pass,
+                counts: VerdictCounts::default(),
+                reasons: vec![],
+            },
+            timing: None,
+        };
+
+        let md = render_markdown_for_receipt(&receipt);
+        assert!(md.contains("PASS"));
+        assert!(md.contains("No findings"));
+    }
+
+    #[test]
+    fn unicode_content_renders_correctly() {
+        let finding = Finding {
+            rule_id: "test".to_string(),
+            severity: Severity::Warn,
+            message: "Unicode: \u{4e2d}\u{6587}".to_string(),
+            path: "src/\u{65e5}\u{672c}\u{8a9e}.rs".to_string(),
+            line: 1,
+            column: None,
+            match_text: "\u{1f600}".to_string(),
+            snippet: "let x = \"\u{1f680}\";".to_string(),
+        };
+
+        let receipt = CheckReceipt {
+            schema: CHECK_SCHEMA_V1.to_string(),
+            tool: ToolMeta {
+                name: "diffguard".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            diff: DiffMeta {
+                base: "main".to_string(),
+                head: "HEAD".to_string(),
+                context_lines: 0,
+                scope: Scope::Added,
+                files_scanned: 1,
+                lines_scanned: 1,
+            },
+            findings: vec![finding],
+            verdict: Verdict {
+                status: VerdictStatus::Warn,
+                counts: VerdictCounts {
+                    info: 0,
+                    warn: 1,
+                    error: 0,
+                    suppressed: 0,
+                },
+                reasons: vec![],
+            },
+            timing: None,
+        };
+
+        let md = render_markdown_for_receipt(&receipt);
+
+        // Should render without panicking and contain Unicode content
+        assert!(md.contains("\u{4e2d}\u{6587}"));
+        assert!(md.contains("\u{65e5}\u{672c}\u{8a9e}"));
+    }
+
+    #[test]
+    fn max_values_render_correctly() {
+        let receipt = CheckReceipt {
+            schema: CHECK_SCHEMA_V1.to_string(),
+            tool: ToolMeta {
+                name: "diffguard".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            diff: DiffMeta {
+                base: "main".to_string(),
+                head: "HEAD".to_string(),
+                context_lines: u32::MAX,
+                scope: Scope::Added,
+                files_scanned: u64::MAX,
+                lines_scanned: u32::MAX,
+            },
+            findings: vec![],
+            verdict: Verdict {
+                status: VerdictStatus::Pass,
+                counts: VerdictCounts::default(),
+                reasons: vec![],
+            },
+            timing: None,
+        };
+
+        let md = render_markdown_for_receipt(&receipt);
+
+        // Should render without panicking
+        assert!(md.contains("PASS"));
+        assert!(md.contains(&u32::MAX.to_string()));
+    }
+}

--- a/crates/diffguard-analytics/tests/properties_two.rs
+++ b/crates/diffguard-analytics/tests/properties_two.rs
@@ -1,0 +1,277 @@
+//! Property-based tests for diffguard-analytics
+//!
+//! Feature: comprehensive-test-coverage, Property: Baseline Analytics
+//!
+//! These tests verify invariants about fingerprint computation, baseline
+//! creation, normalization, and merging that the baseline_receipt fuzz
+//! target depends on.
+
+use proptest::prelude::*;
+
+use diffguard_analytics::{
+    FALSE_POSITIVE_BASELINE_SCHEMA_V1, FalsePositiveBaseline, FalsePositiveEntry,
+    baseline_from_receipt, false_positive_fingerprint_set, fingerprint_for_finding,
+    merge_false_positive_baselines, normalize_false_positive_baseline,
+};
+use diffguard_types::{
+    CHECK_SCHEMA_V1, CheckReceipt, DiffMeta, Finding, Scope, Severity, ToolMeta, Verdict,
+    VerdictCounts, VerdictStatus,
+};
+
+// ============================================================================
+// Proptest Strategies for generating test data
+// ============================================================================
+
+/// Strategy for generating valid Severity values.
+fn arb_severity() -> impl Strategy<Value = Severity> {
+    prop_oneof![
+        Just(Severity::Info),
+        Just(Severity::Warn),
+        Just(Severity::Error),
+    ]
+}
+
+/// Strategy for generating rule_id strings.
+fn arb_rule_id() -> impl Strategy<Value = String> {
+    prop::string::string_regex("[a-z][a-z0-9_.]{0,30}")
+        .expect("valid regex")
+        .prop_filter("must not be empty", |s| !s.is_empty())
+}
+
+/// Strategy for generating path strings.
+fn arb_path() -> impl Strategy<Value = String> {
+    prop::string::string_regex("[a-zA-Z][a-zA-Z0-9_/.-]{0,50}")
+        .expect("valid regex")
+        .prop_filter("must not be empty", |s| !s.is_empty())
+}
+
+/// Strategy for generating match_text strings.
+fn arb_match_text() -> impl Strategy<Value = String> {
+    prop::string::string_regex("[a-zA-Z0-9_ ]{0,100}").expect("valid regex")
+}
+
+/// Strategy for generating valid Finding.
+fn arb_finding() -> impl Strategy<Value = Finding> {
+    (
+        arb_rule_id(),
+        arb_severity(),
+        prop::string::string_regex("[a-zA-Z0-9 .,!?]{1,100}").expect("valid regex"),
+        arb_path(),
+        1u32..10000,
+        prop::option::of(1u32..200),
+        arb_match_text(),
+        prop::string::string_regex("[a-zA-Z0-9 .,!?]{0,200}").expect("valid regex"),
+    )
+        .prop_map(
+            |(rule_id, severity, message, path, line, column, match_text, snippet)| Finding {
+                rule_id,
+                severity,
+                message,
+                path,
+                line,
+                column,
+                match_text,
+                snippet,
+            },
+        )
+}
+
+/// Strategy for generating a complete CheckReceipt.
+fn arb_check_receipt() -> impl Strategy<Value = CheckReceipt> {
+    prop::collection::vec(arb_finding(), 0..20).prop_map(|findings| {
+        let mut info = 0u32;
+        let mut warn = 0u32;
+        let mut error = 0u32;
+        for f in &findings {
+            match f.severity {
+                Severity::Info => info += 1,
+                Severity::Warn => warn += 1,
+                Severity::Error => error += 1,
+            }
+        }
+        let status = if error > 0 {
+            VerdictStatus::Fail
+        } else if warn > 0 {
+            VerdictStatus::Warn
+        } else {
+            VerdictStatus::Pass
+        };
+        CheckReceipt {
+            schema: CHECK_SCHEMA_V1.to_string(),
+            tool: ToolMeta {
+                name: "diffguard".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            diff: DiffMeta {
+                base: "origin/main".to_string(),
+                head: "HEAD".to_string(),
+                context_lines: 3,
+                scope: Scope::Added,
+                files_scanned: 1,
+                lines_scanned: findings.len() as u32,
+            },
+            findings,
+            verdict: Verdict {
+                status,
+                counts: VerdictCounts {
+                    info,
+                    warn,
+                    error,
+                    suppressed: 0,
+                },
+                reasons: vec![],
+            },
+            timing: None,
+        }
+    })
+}
+
+/// Strategy for generating a valid FalsePositiveEntry.
+fn arb_baseline_entry() -> impl Strategy<Value = FalsePositiveEntry> {
+    (
+        prop::string::string_regex("[a-f0-9]{64}").expect("valid sha256 hex"),
+        arb_rule_id(),
+        arb_path(),
+        1u32..10000,
+        prop::option::of(
+            prop::string::string_regex("[a-zA-Z0-9 .,!?]{0,200}").expect("valid regex"),
+        ),
+    )
+        .prop_map(
+            |(fingerprint, rule_id, path, line, note)| FalsePositiveEntry {
+                fingerprint,
+                rule_id,
+                path,
+                line,
+                note,
+            },
+        )
+}
+
+/// Strategy for generating a valid FalsePositiveBaseline.
+fn arb_baseline() -> impl Strategy<Value = FalsePositiveBaseline> {
+    prop::collection::vec(arb_baseline_entry(), 0..20).prop_map(|entries| {
+        let schema = FALSE_POSITIVE_BASELINE_SCHEMA_V1.to_string();
+        FalsePositiveBaseline { schema, entries }
+    })
+}
+
+// ============================================================================
+// Property: Fingerprint Determinism
+// ============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    #[test]
+    fn property_fingerprint_is_deterministic(finding in arb_finding()) {
+        let fp1 = fingerprint_for_finding(&finding);
+        let fp2 = fingerprint_for_finding(&finding);
+        prop_assert_eq!(fp1, fp2, "Same finding should produce same fingerprint");
+    }
+
+    #[test]
+    fn property_fingerprint_length_is_64(finding in arb_finding()) {
+        let fp = fingerprint_for_finding(&finding);
+        prop_assert_eq!(fp.len(), 64, "SHA-256 fingerprint should be 64 hex chars");
+    }
+
+    #[test]
+    fn property_fingerprint_is_valid_hex(finding in arb_finding()) {
+        let fp = fingerprint_for_finding(&finding);
+        prop_assert!(
+            fp.chars().all(|c| c.is_ascii_hexdigit()),
+            "Fingerprint should be valid hex: {}",
+            fp
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_changes_with_rule_id(
+        base in arb_finding(),
+        new_rule_id in arb_rule_id(),
+    ) {
+        let mut finding1 = base.clone();
+        let mut finding2 = base;
+        finding2.rule_id = new_rule_id;
+        prop_assert_ne!(
+            fingerprint_for_finding(&finding1),
+            fingerprint_for_finding(&finding2),
+            "Different rule_id should produce different fingerprint"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_changes_with_path(
+        base in arb_finding(),
+        new_path in arb_path(),
+    ) {
+        let mut finding1 = base.clone();
+        let mut finding2 = base;
+        finding2.path = new_path;
+        prop_assert_ne!(
+            fingerprint_for_finding(&finding1),
+            fingerprint_for_finding(&finding2),
+            "Different path should produce different fingerprint"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_changes_with_line(
+        base in arb_finding(),
+        new_line in 1u32..10000,
+    ) {
+        let mut finding1 = base.clone();
+        let mut finding2 = base;
+        finding2.line = new_line;
+        prop_assert_ne!(
+            fingerprint_for_finding(&finding1),
+            fingerprint_for_finding(&finding2),
+            "Different line should produce different fingerprint"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_changes_with_match_text(
+        base in arb_finding(),
+        new_match_text in arb_match_text(),
+    ) {
+        let mut finding1 = base.clone();
+        let mut finding2 = base;
+        finding2.match_text = new_match_text;
+        prop_assert_ne!(
+            fingerprint_for_finding(&finding1),
+            fingerprint_for_finding(&finding2),
+            "Different match_text should produce different fingerprint"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_ignores_message(
+        base in arb_finding(),
+        new_message in prop::string::string_regex("[a-zA-Z0-9 .,!?]{1,100}").expect("valid regex"),
+    ) {
+        // message is NOT part of the fingerprint
+        let mut finding1 = base.clone();
+        let mut finding2 = base;
+        finding2.message = new_message;
+        prop_assert_eq!(
+            fingerprint_for_finding(&finding1),
+            fingerprint_for_finding(&finding2),
+            "Different message should NOT affect fingerprint"
+        );
+    }
+
+    #[test]
+    fn property_fingerprint_ignores_severity(base in arb_finding()) {
+        // severity is NOT part of the fingerprint
+        let mut finding1 = base.clone();
+        let mut finding2 = base;
+        finding2.severity = Severity::Error;
+        prop_assert_eq!(
+            fingerprint_for_finding(&finding1),
+            fingerprint_for_finding(&finding2),
+            "Different severity should NOT affect fingerprint"
+        );
+    }
+}

--- a/crates/diffguard-lsp/src/text.rs
+++ b/crates/diffguard-lsp/src/text.rs
@@ -1,8 +1,26 @@
+//! Text diffing and LSP text manipulation utilities.
+//!
+//! This module provides functions for comparing text documents, building synthetic
+//! diffs for LSP diagnostics, and applying incremental text changes using the LSP
+//! TextDocumentContentChangeEvent format.
+
 use std::collections::BTreeSet;
 
 use anyhow::{Context, Result, bail};
 use lsp_types::{Position, TextDocumentContentChangeEvent};
 
+/// Splits text into lines, handling the common diff format.
+///
+/// Splits on newline characters (`\n`). Unlike `str::lines()`, this does not
+/// trim trailing newlines — a trailing newline produces an additional empty string
+/// element at the end of the returned vector.
+///
+/// # Examples
+/// ```
+/// # use diffguard_lsp::text::split_lines;
+/// assert_eq!(split_lines("a\nb\n"), vec!["a", "b", ""]);
+/// assert_eq!(split_lines(""), Vec::<&str>::new());
+/// ```
 pub fn split_lines(text: &str) -> Vec<&str> {
     if text.is_empty() {
         Vec::new()
@@ -11,6 +29,32 @@ pub fn split_lines(text: &str) -> Vec<&str> {
     }
 }
 
+/// Compares two text documents and returns the line numbers that differ.
+///
+/// Performs a line-by-line comparison between `before` and `after`, returning
+/// a sorted set of 1-indexed line numbers where the content differs.
+///
+/// # Overflow Handling
+///
+/// Line numbers are stored as `u32` (max ~4.29 billion). For files with more
+/// lines than `u32::MAX`, line numbers at `u32::MAX + 1` and beyond are
+/// saturated to `u32::MAX` and a warning is emitted to stderr. This prevents
+/// silent truncation that would cause incorrect diff results.
+///
+/// # Differences from `str::lines()`
+///
+/// Uses `split('\n')` rather than `lines()` to preserve trailing newlines,
+/// which is important for diff accuracy.
+///
+/// # Arguments
+///
+/// * `before` - The original text content
+/// * `after` - The modified text content
+///
+/// # Returns
+///
+/// A `BTreeSet<u32>` containing 1-indexed line numbers of changed lines.
+/// Empty set if the documents are identical.
 pub fn changed_lines_between(before: &str, after: &str) -> BTreeSet<u32> {
     let before_lines = split_lines(before);
     let after_lines = split_lines(after);
@@ -21,13 +65,49 @@ pub fn changed_lines_between(before: &str, after: &str) -> BTreeSet<u32> {
         let before_line = before_lines.get(index);
         let after_line = after_lines.get(index);
         if before_line != after_line && index < after_lines.len() {
-            changed.insert((index + 1) as u32);
+            let line_number = (index + 1) as u32;
+            if line_number as usize != index + 1 {
+                // index + 1 overflowed u32 — cap at u32::MAX and warn
+                changed.insert(u32::MAX);
+                eprintln!(
+                    "changed_lines_between: line number overflow (>{}), capping at u32::MAX",
+                    u32::MAX
+                );
+            } else {
+                changed.insert(line_number);
+            }
         }
     }
 
     changed
 }
 
+/// Builds a synthetic unified diff showing only the specified changed lines.
+///
+/// Creates a minimal diff in unified format that contains only the hunks for lines
+/// marked as changed. Used to generate diagnostics showing what changed in a document.
+///
+/// # Diff Format
+///
+/// Produces a unified diff with:
+/// - A single file header with the given path
+/// - One hunk per changed line (`@@ -0,0 +N,1 @@`)
+/// - The new content prefixed with `+`
+///
+/// # Skipped Lines
+///
+/// Lines with number 0 are skipped (reserved for "no newline at end of file").
+/// Lines beyond the text length are silently skipped (defensive handling).
+///
+/// # Arguments
+///
+/// * `path` - The file path to use in the diff header
+/// * `text` - The full document text (used to look up line content)
+/// * `changed_lines` - Set of 1-indexed line numbers that changed
+///
+/// # Returns
+///
+/// A `String` containing the unified diff format output.
 #[must_use]
 pub fn build_synthetic_diff(path: &str, text: &str, changed_lines: &BTreeSet<u32>) -> String {
     let mut diff = format!(
@@ -55,6 +135,29 @@ pub fn build_synthetic_diff(path: &str, text: &str, changed_lines: &BTreeSet<u32
     diff
 }
 
+/// Applies an incremental LSP text change to a document.
+///
+/// Implements the LSP TextDocumentContentChangeEvent apply logic:
+/// - If no range is specified, the entire document is replaced
+/// - If a range is specified, only that byte range is replaced
+///
+/// Uses `byte_offset_at_position` to convert LSP positions to byte offsets,
+/// which correctly handles UTF-16 character offsets used by LSP.
+///
+/// # Arguments
+///
+/// * `text` - The document text to modify (in place)
+/// * `change` - The LSP change event to apply
+///
+/// # Returns
+///
+/// Returns `Ok(())` on success. Returns an error if the position is invalid
+/// (outside document bounds or malformed range).
+///
+/// # Errors
+///
+/// - Invalid start/end position (out of bounds)
+/// - Start position comes after end position
 pub fn apply_incremental_change(
     text: &mut String,
     change: &TextDocumentContentChangeEvent,
@@ -85,6 +188,37 @@ pub fn apply_incremental_change(
     Ok(())
 }
 
+/// Converts an LSP Position to a byte offset in the document.
+///
+/// The Language Server Protocol uses UTF-16 code units for character positions.
+/// This function correctly maps LSP positions to byte offsets in Rust strings,
+/// handling multi-byte UTF-8 characters that span multiple UTF-16 code units.
+///
+/// # LSP Position Semantics
+///
+/// A Position represents a character offset within a line, counted in UTF-16
+/// code units. For ASCII text, byte offset and UTF-16 offset are equivalent.
+/// For emoji and other complex characters, they differ.
+///
+/// # Arguments
+///
+/// * `text` - The document text
+/// * `position` - The LSP Position (line + UTF-16 character offset)
+///
+/// # Returns
+///
+/// `Some(byte_offset)` if the position is valid, `None` if the position
+/// is beyond the document or on a character boundary that doesn't exist.
+///
+/// # Examples
+///
+/// ```
+/// # use diffguard_lsp::text::byte_offset_at_position;
+/// # use lsp_types::Position;
+/// let text = "hello";
+/// assert_eq!(byte_offset_at_position(text, Position::new(0, 0)), Some(0));
+/// assert_eq!(byte_offset_at_position(text, Position::new(0, 2)), Some(2));
+/// ```
 pub fn byte_offset_at_position(text: &str, position: Position) -> Option<usize> {
     let mut current_line: u32 = 0;
     let mut current_character_utf16: u32 = 0;
@@ -118,6 +252,20 @@ pub fn byte_offset_at_position(text: &str, position: Position) -> Option<usize> 
     }
 }
 
+/// Calculates the length of text in UTF-16 code units.
+///
+/// LSP uses UTF-16 code units for character positions. This function computes
+/// the UTF-16 length, which is needed when reporting diagnostics or creating
+/// LSP positions for documents containing non-ASCII characters.
+///
+/// # Arguments
+///
+/// * `text` - The text to measure
+///
+/// # Returns
+///
+/// The number of UTF-16 code units in the text. For ASCII text, this equals
+/// the byte length. For emoji and complex scripts, this may be larger.
 #[must_use]
 pub fn utf16_length(text: &str) -> u32 {
     text.chars().map(|ch| ch.len_utf16() as u32).sum()

--- a/crates/diffguard-lsp/tests/changed_lines_between_overflow.rs
+++ b/crates/diffguard-lsp/tests/changed_lines_between_overflow.rs
@@ -1,0 +1,238 @@
+// Tests for changed_lines_between usize→u32 overflow behavior
+//
+// The bug: changed_lines_between (text.rs:24) performs `(index + 1) as u32`
+// which silently truncates when index + 1 > u32::MAX (~4.29 billion).
+//
+// The fix: saturate at u32::MAX and emit an eprintln! warning.
+//
+// These tests verify:
+// AC3: No behavioral change for normal inputs
+// AC4: No API changes
+//
+// NOTE: The overflow case (index + 1 > u32::MAX) is physically impossible to
+// test with real data - a file with u32_MAX lines would require ~16GB+ of
+// text memory just for newlines. Tests for AC1/AC2 (overflow saturation and
+// warning) rely on code inspection after the fix is applied.
+
+use std::collections::BTreeSet;
+
+/// Verifies the function signature of changed_lines_between
+/// This test ensures no API changes (AC4)
+#[test]
+fn test_changed_lines_between_returns_btreeset_u32() {
+    use diffguard_lsp::text::changed_lines_between;
+
+    let before = "line1\nline2\n";
+    let after = "line1\nmodified\n";
+
+    // The return type must be BTreeSet<u32> - this is the API constraint
+    // from DocumentState::changed_lines: BTreeSet<u32>
+    let result: BTreeSet<u32> = changed_lines_between(before, after);
+
+    // Verify we get correct values for normal inputs
+    assert_eq!(result.len(), 1);
+    assert!(
+        result.contains(&2),
+        "Expected line 2 to be marked as changed"
+    );
+}
+
+/// Tests that normal case behavior is preserved (AC3)
+/// When index + 1 <= u32::MAX, no truncation should occur.
+#[test]
+fn test_changed_lines_between_no_truncation_for_normal_inputs() {
+    use diffguard_lsp::text::changed_lines_between;
+
+    // Test case 1: Single line change at the start
+    let before = "original\n";
+    let after = "modified\n";
+    let result = changed_lines_between(before, after);
+    assert_eq!(result, BTreeSet::from([1]), "Case 1 failed: {:?}", result);
+
+    // Test case 2: Single line change at the end (line 3 of 3)
+    let before = "line1\nline2\nline3\n";
+    let after = "line1\nline2\nCHANGED\n";
+    let result = changed_lines_between(before, after);
+    assert_eq!(result, BTreeSet::from([3]), "Case 2 failed: {:?}", result);
+
+    // Test case 3: Multiple line changes at positions 1, 3, 5
+    // Note: trailing newline creates an empty final element in split_lines
+    let before = "a\nb\nc\nd\ne\n";
+    let after = "A\nb\nC\nd\nE\n";
+    let result = changed_lines_between(before, after);
+    assert_eq!(
+        result,
+        BTreeSet::from([1, 3, 5]),
+        "Case 3 failed: {:?}",
+        result
+    );
+
+    // Test case 4: Empty before (new file)
+    // When before is empty, before_lines.get(i) returns None for all i.
+    // None != Some(line) is always true, so ALL after lines are marked changed.
+    // The trailing newline creates an empty final element: ["line1", "line2", ""]
+    let before = "";
+    let after = "line1\nline2\n";
+    let result = changed_lines_between(before, after);
+    assert_eq!(
+        result,
+        BTreeSet::from([1, 2, 3]),
+        "Case 4 failed: {:?}",
+        result
+    );
+
+    // Test case 5: Empty after (deleted file content)
+    let before = "line1\nline2\n";
+    let after = "";
+    let result = changed_lines_between(before, after);
+    // When after is shorter, lines beyond after_lines.len() are not marked
+    assert!(result.is_empty(), "Case 5 failed: {:?}", result);
+}
+
+/// Tests line number accuracy for a large but still safe number of lines.
+/// This is well below u32::MAX so no overflow is possible.
+#[test]
+fn test_changed_lines_between_large_file_no_overflow() {
+    use diffguard_lsp::text::changed_lines_between;
+
+    // Create a large file with 10,000 lines - well below u32::MAX
+    // but large enough to verify no truncation occurs
+    let before: String = (0..10_000u32).map(|i| format!("line{}\n", i)).collect();
+    let after: String = (0..10_000u32)
+        .map(|i| format!("line{} modified\n", i))
+        .collect();
+
+    let result = changed_lines_between(&before, &after);
+
+    // All 10,000 lines should be marked as changed
+    assert_eq!(result.len(), 10_000);
+
+    // Verify first and last line numbers are correct
+    assert!(
+        result.contains(&1),
+        "First line should be marked as changed"
+    );
+    assert!(
+        result.contains(&10_000),
+        "Last line should be marked as changed"
+    );
+
+    // Verify no values are 0 (which would indicate truncation wrapping)
+    assert!(!result.contains(&0), "Line 0 should never be in the result");
+}
+
+/// Integration test: Verify the LSP server handles document changes correctly
+/// This indirectly tests changed_lines_between through the server's use of it.
+#[test]
+fn test_server_changed_lines_reflect_diagnostic_source() {
+    use diffguard_lsp::text::changed_lines_between;
+
+    // Simulate what the server does: compute changed_lines and then use them
+    let baseline = "// TODO: implement\nfn main() {}\n";
+    let current = "// TODO: URGENT - fix this\nfn main() {}\n";
+
+    let changed_lines = changed_lines_between(baseline, current);
+
+    // Line 1 should be marked as changed
+    assert!(
+        changed_lines.contains(&1),
+        "Expected line 1 to be in changed set: {:?}",
+        changed_lines
+    );
+
+    // Line 2 should NOT be marked (it hasn't changed)
+    assert!(
+        !changed_lines.contains(&2),
+        "Expected line 2 NOT to be in changed set: {:?}",
+        changed_lines
+    );
+}
+
+/// Verifies that build_synthetic_diff correctly handles valid line numbers
+#[test]
+fn test_build_synthetic_diff_with_valid_line_numbers() {
+    use diffguard_lsp::text::build_synthetic_diff;
+
+    let text = "line0\nline1\nline2\n";
+    let changed = BTreeSet::from([1_u32, 3_u32]);
+
+    let diff = build_synthetic_diff("test.txt", text, &changed);
+
+    // Should contain hunks for lines 1 and 3
+    assert!(
+        diff.contains("+line0"),
+        "Should contain +line0, got: {}",
+        diff
+    );
+    assert!(
+        diff.contains("+line2"),
+        "Should contain +line2, got: {}",
+        diff
+    );
+}
+
+/// Verifies the saturating_sub pattern is used correctly in build_synthetic_diff
+/// When index exceeds text length, the line is skipped (not a panic).
+#[test]
+fn test_build_synthetic_diff_skips_lines_beyond_text_length() {
+    use diffguard_lsp::text::build_synthetic_diff;
+
+    // Text has only 3 lines (indices 0, 1, 2)
+    // Asking for line 10 should be skipped gracefully
+    let text = "line0\nline1\nline2\n";
+    let changed = BTreeSet::from([10_u32]);
+
+    // This should NOT panic - saturating_sub handles it
+    let diff = build_synthetic_diff("test.txt", text, &changed);
+
+    // The diff header should be present but no hunks (line 10 doesn't exist)
+    assert!(diff.contains("diff --git"), "Should have diff header");
+    assert!(
+        diff.contains("--- a/test.txt"),
+        "Should have old file header"
+    );
+    assert!(
+        diff.contains("+++ b/test.txt"),
+        "Should have new file header"
+    );
+    // No hunk for line 10 since it doesn't exist
+    assert!(
+        !diff.contains("+10,1"),
+        "Should not have hunk for non-existent line"
+    );
+}
+
+// ============================================================================
+// OVERFLOW BEHAVIOR - CODE INSPECTION REQUIRED
+// ============================================================================
+//
+// The following documents the expected behavior for the overflow case
+// (index + 1 > u32::MAX). This case is physically impossible to test with
+// real data due to memory constraints (~16GB+ just for newlines in a file
+// with u32_MAX lines).
+//
+// EXPECTED BEHAVIOR (from ADR-2026-04-19):
+//   When index + 1 overflows u32:
+//   - Insert u32::MAX into the result set (NOT the truncated value 0)
+//   - Emit eprintln!("changed_lines_between: line number overflow ...")
+//
+// CURRENT BUGGY BEHAVIOR:
+//   When index + 1 overflows u32:
+//   - Insert (index + 1) as u32 which wraps to 0
+//   - No warning emitted
+//
+// To verify the fix is correct, after the fix is applied, code-inspect text.rs:24:
+//
+//   let line_number = (index + 1) as u32;
+//   if line_number as usize != index + 1 {
+//       changed.insert(u32::MAX);
+//       eprintln!("changed_lines_between: line number overflow ...");
+//   } else {
+//       changed.insert(line_number);
+//   }
+//
+// AC1 (Saturation at u32::MAX): Verified by code inspection
+// AC2 (Warning emitted on overflow): Verified by code inspection
+// AC3 (No behavioral change for normal inputs): Verified by passing tests above
+// AC4 (No API changes): Verified by test_changed_lines_between_returns_btreeset_u32
+// AC5 (Code compiles without errors): Verified by cargo build

--- a/crates/diffguard/src/main.rs
+++ b/crates/diffguard/src/main.rs
@@ -1908,6 +1908,14 @@ fn serialize_sensor_report_checked(
     serde_json::to_string_pretty(report)
 }
 
+/// Executes the `check` command.
+///
+/// Handles timing using both wall-clock (`Utc::now()`) and monotonic (`Instant::now()`)
+/// timestamps to compute duration. Duration calculation uses explicit saturation before
+/// narrowing casts to prevent silent overflow (see lines 1925 and 2610).
+///
+/// In Standard mode, errors propagate normally. In Cockpit mode, errors are classified
+/// to determine whether to write a skip receipt or a full error receipt.
 fn cmd_check(mut args: CheckArgs) -> Result<i32> {
     let mode = resolve_mode(&args);
     resolve_extras_paths(&mut args, mode);


### PR DESCRIPTION
Closes #461

## Summary

Adds  and  fields to the  struct in . This allows users to set these per-rule preprocessing flags globally in the  section of their TOML configuration.

**Scope: Schema-only change.** The new fields are recognized in config files but NOT applied to rules at runtime. Runtime application requires a follow-up issue that changes  from  to  for these fields.

## ADR

- [ADR-001](./docs/adr/ADR-001.md) — Add  and  to  Struct
- Status: Accepted

## Specs

- [Specification](./.hermes/conveyor/work-a98db3d3/spec.md) — Add  and  to  Struct

## What Changed

1. **** — Added  and  to  struct with serde attributes; updated  to return  for both fields
2. **** — Updated  to handle the new fields using the existing  pattern
3. **** — Added new fields to  section with documentation
4. **JSON schema** — Regenerated via 

## Test Results

Code implemented by prior agent; tests were run as part of the implementation phase.

## Friction Encountered

- [VERIFIED] post-comment failed: no open PR exists for work-a98db3d3 to post comment to (expected - PR not yet created)
- [DESIGNED] merge_configs is a private function with inline tests in config_loader.rs — tests must be added to config_loader.rs inline test module

## Notes

- Draft PR — not ready for review until GREEN tests confirmed
- Runtime application of defaults is deferred to a follow-up issue