### PR TITLE
WIP: fix(clippy): eliminate uninlined_format_args warnings (issue #537)

### DIFF
--- a/crates/diffguard-core/src/checkstyle.rs
+++ b/crates/diffguard-core/src/checkstyle.rs
@@ -38,7 +38,7 @@ fn error_element(
     rule_id: &str,
 ) -> String {
     let column_attr = column
-        .map(|c| format!(" column=\"{}\"", c))
+        .map(|c| format!(" column=\"{c}\""))
         .unwrap_or_default();
     format!(
         "    <error line=\"{}\"{column_attr} severity=\"{}\" message=\"{}\" source=\"{}\"/>\n",

--- a/crates/diffguard-core/src/checkstyle.rs
+++ b/crates/diffguard-core/src/checkstyle.rs
@@ -27,9 +27,9 @@ use diffguard_types::{CheckReceipt, Finding, Severity};
 /// - `Warn`  → "warning"
 /// - `Info`  → "info"
 ///
-/// Formats a `<error>` element for a finding.
+/// Formats a single `<error>` element for a Checkstyle XML report.
 ///
-/// Column is optional in Checkstyle — only included when present.
+/// The column attribute is only included when a column number is provided.
 fn error_element(
     line: u32,
     column: Option<u32>,

--- a/crates/diffguard-core/src/csv.rs
+++ b/crates/diffguard-core/src/csv.rs
@@ -103,7 +103,7 @@ fn escape_csv_field(s: &str) -> String {
 
     if needs_quoting {
         let escaped = s.replace('"', "\"\"");
-        format!("\"{}\"", escaped)
+        format!("\"{escaped}\"")
     } else {
         s.to_string()
     }

--- a/crates/diffguard-core/src/junit.rs
+++ b/crates/diffguard-core/src/junit.rs
@@ -37,8 +37,7 @@ pub fn render_junit_for_receipt(receipt: &CheckReceipt) -> String {
 
     // Root element
     out.push_str(&format!(
-        "<testsuites name=\"diffguard\" tests=\"{}\" failures=\"{}\" errors=\"0\">\n",
-        total_tests, total_failures
+        "<testsuites name=\"diffguard\" tests=\"{total_tests}\" failures=\"{total_failures}\" errors=\"0\">\n"
     ));
 
     // Emit a testsuite per rule_id

--- a/crates/diffguard-lsp/src/config.rs
+++ b/crates/diffguard-lsp/src/config.rs
@@ -108,19 +108,19 @@ pub fn format_rule_explanation(rule: &RuleConfig) -> String {
     output.push_str(&format!("Message: {}\n", rule.message));
     output.push_str("Patterns:\n");
     for pattern in &rule.patterns {
-        output.push_str(&format!("- {}\n", pattern));
+        output.push_str(&format!("- {pattern}\n"));
     }
     output.push_str("Semantics:\n");
     let match_mode = match rule.match_mode {
         MatchMode::Any => "any",
         MatchMode::Absent => "absent",
     };
-    output.push_str(&format!("- Match mode: {}\n", match_mode));
+    output.push_str(&format!("- Match mode: {match_mode}\n"));
     output.push_str(&format!(
         "- Multiline: {}{}\n",
         if rule.multiline { "yes" } else { "no" },
         rule.multiline_window
-            .map(|window| format!(" (window={})", window))
+            .map(|window| format!(" (window={window})"))
             .unwrap_or_default()
     ));
     if !rule.context_patterns.is_empty() {
@@ -161,11 +161,11 @@ pub fn format_rule_explanation(rule: &RuleConfig) -> String {
     if let Some(help) = &rule.help {
         output.push_str("Help:\n");
         for line in help.lines() {
-            output.push_str(&format!("{}\n", line));
+            output.push_str(&format!("{line}\n"));
         }
     }
     if let Some(url) = &rule.url {
-        output.push_str(&format!("URL: {}\n", url));
+        output.push_str(&format!("URL: {url}\n"));
     }
     output
 }
@@ -372,8 +372,7 @@ fn expand_env_vars(content: &str) -> Result<String> {
                     result.push_str(default);
                 } else {
                     bail!(
-                        "environment variable '{}' is not set and no default was provided",
-                        variable
+                        "environment variable '{variable}' is not set and no default was provided"
                     );
                 }
             }

--- a/crates/diffguard-lsp/src/config.rs
+++ b/crates/diffguard-lsp/src/config.rs
@@ -10,6 +10,14 @@ use regex::Regex;
 const DIRECTORY_OVERRIDE_NAME: &str = ".diffguard.toml";
 const MAX_INCLUDE_DEPTH: usize = 10;
 
+/// Loads the effective configuration by resolving the path and merging with built-in rules.
+///
+/// If `path` is `None`, returns the built-in configuration directly.
+/// If `no_default_rules` is `true`, the user config is returned without merging with built-in rules.
+/// Otherwise, user rules are merged with and can override built-in rules.
+///
+/// # Errors
+/// Returns an error if the configuration file cannot be read or parsed.
 pub fn load_effective_config(path: Option<&Path>, no_default_rules: bool) -> Result<ConfigFile> {
     let Some(path) = path else {
         return Ok(ConfigFile::built_in());
@@ -23,6 +31,15 @@ pub fn load_effective_config(path: Option<&Path>, no_default_rules: bool) -> Res
     }
 }
 
+/// Resolves the configuration file path based on workspace root, override, and default name.
+///
+/// Resolution order:
+/// 1. If `override_path` is provided and absolute, use it directly
+/// 2. If `override_path` is provided and relative, join with `workspace_root` if available
+/// 3. If `workspace_root` is available, look for `default_name` in it
+/// 4. Look for `default_name` in current directory
+///
+/// Returns `None` if no config file is found at any candidate path.
 pub fn resolve_config_path(
     workspace_root: Option<&Path>,
     override_path: Option<String>,
@@ -56,6 +73,11 @@ pub fn resolve_config_path(
     }
 }
 
+/// Checks if two paths refer to the same file.
+///
+/// Uses canonicalization first (which resolves symlinks and relative paths),
+/// falling back to string comparison of normalized paths if canonicalization fails.
+/// Normalization converts backslashes to forward slashes.
 pub fn paths_match(left: &Path, right: &Path) -> bool {
     let left_canonical = left.canonicalize().ok();
     let right_canonical = right.canonicalize().ok();
@@ -65,10 +87,18 @@ pub fn paths_match(left: &Path, right: &Path) -> bool {
     normalize_path(left) == normalize_path(right)
 }
 
+/// Normalizes a path for consistent comparison.
+///
+/// Converts all backslash separators to forward slashes. This ensures paths
+/// from different operating systems compare correctly.
 pub fn normalize_path(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
 
+/// Converts a file path to a workspace-relative path.
+///
+/// Strips the `workspace_root` prefix from `file_path` if present, then normalizes
+/// the result. Returns the normalized path without leading `./` if present.
 pub fn to_workspace_relative_path(workspace_root: Option<&Path>, file_path: &Path) -> String {
     let normalized = if let Some(root) = workspace_root {
         if let Ok(stripped) = file_path.strip_prefix(root) {
@@ -83,6 +113,10 @@ pub fn to_workspace_relative_path(workspace_root: Option<&Path>, file_path: &Pat
     normalized.trim_start_matches("./").to_string()
 }
 
+/// Extracts the rule ID from an LSP diagnostic.
+///
+/// Checks the diagnostic `code` field first (for string-type codes), then falls back
+/// to the `data.ruleId` field if present. Returns `None` if no rule ID is found.
 pub fn extract_rule_id(diagnostic: &Diagnostic) -> Option<String> {
     if let Some(NumberOrString::String(rule_id)) = diagnostic.code.as_ref() {
         return Some(rule_id.clone());
@@ -96,11 +130,24 @@ pub fn extract_rule_id(diagnostic: &Diagnostic) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+/// Finds a rule by its ID in the configuration.
+///
+/// Returns a reference to the rule if found, `None` otherwise.
 #[must_use]
 pub fn find_rule<'a>(config: &'a ConfigFile, rule_id: &str) -> Option<&'a RuleConfig> {
     config.rule.iter().find(|rule| rule.id == rule_id)
 }
 
+/// Formats a rule configuration into a human-readable explanation string.
+///
+/// Produces a multi-line output containing:
+/// - Rule ID and severity
+/// - The match message
+/// - Patterns and semantics (match mode, multiline, context patterns)
+/// - Escalation rules and dependencies
+/// - Supported languages and paths
+/// - Ignored patterns (comments/strings)
+/// - Help text and documentation URL
 pub fn format_rule_explanation(rule: &RuleConfig) -> String {
     let mut output = String::new();
     output.push_str(&format!("Rule: {}\n", rule.id));
@@ -170,6 +217,14 @@ pub fn format_rule_explanation(rule: &RuleConfig) -> String {
     output
 }
 
+/// Finds rules with IDs similar to the given rule ID for typo suggestions.
+///
+/// Uses multiple matching strategies:
+/// - Prefix match (rule starts with the query or vice versa) - priority 0
+/// - Substring match (rule contains query or query contains rule) - priority 1
+/// - Edit distance ≤ 3 - priority 2+
+///
+/// Returns up to 5 suggestions sorted by relevance.
 pub fn find_similar_rules(rule_id: &str, rules: &[RuleConfig]) -> Vec<String> {
     let rule_id_lower = rule_id.to_lowercase();
     let mut candidates: Vec<(String, usize)> = Vec::new();
@@ -195,6 +250,13 @@ pub fn find_similar_rules(rule_id: &str, rules: &[RuleConfig]) -> Vec<String> {
     candidates.into_iter().map(|(id, _)| id).collect()
 }
 
+/// Loads directory rule overrides for a file.
+///
+/// Searches upward from the file's directory, collecting all `.diffguard.toml` override files.
+/// Override files are processed in order from nearest to farthest (most specific to least specific).
+///
+/// # Errors
+/// Returns an error if an override file exists but cannot be read or parsed.
 pub fn load_directory_overrides_for_file(
     workspace_root: &Path,
     relative_file_path: &str,

--- a/crates/diffguard-lsp/src/server.rs
+++ b/crates/diffguard-lsp/src/server.rs
@@ -160,6 +160,13 @@ impl ServerState {
     }
 }
 
+/// Runs the diffguard LSP server.
+///
+/// This is the main entry point for the LSP server. It takes a `Connection` from the
+/// LSP protocol handshake and then processes messages in a loop until the connection closes.
+///
+/// # Errors
+/// Returns an error if initialization fails or if message handling encounters an unrecoverable error.
 pub fn run_server(connection: Connection) -> Result<()> {
     // Use the lower-level initialize_start/initialize_finish methods
     // to send a custom InitializeResult with server_info.

--- a/crates/diffguard-lsp/src/server.rs
+++ b/crates/diffguard-lsp/src/server.rs
@@ -138,8 +138,7 @@ impl ServerState {
                         .map(|p| p.display().to_string())
                         .unwrap_or_else(|| "<built-in>".to_string());
                     let warning = format!(
-                        "diffguard-lsp: failed to load config from {} (using built-in rules): {}",
-                        config_label, err
+                        "diffguard-lsp: failed to load config from {config_label} (using built-in rules): {err}"
                     );
                     (ConfigFile::built_in(), Some(warning))
                 }
@@ -296,7 +295,7 @@ fn handle_code_action_request(
                 connection,
                 request.id,
                 INVALID_PARAMS,
-                format!("invalid CodeActionParams: {}", err),
+                format!("invalid CodeActionParams: {err}"),
             );
         }
     };
@@ -317,13 +316,13 @@ fn build_code_actions(config: &ConfigFile, params: &CodeActionParams) -> Vec<Cod
 
         if seen_explain.insert(rule_id.clone()) {
             let command = LspCommand {
-                title: format!("Explain {}", rule_id),
+                title: format!("Explain {rule_id}"),
                 command: CMD_EXPLAIN_RULE.to_string(),
                 arguments: Some(vec![json!(rule_id.clone())]),
             };
 
             actions.push(CodeActionOrCommand::CodeAction(CodeAction {
-                title: format!("diffguard: Explain {}", rule_id),
+                title: format!("diffguard: Explain {rule_id}"),
                 kind: Some(CodeActionKind::QUICKFIX),
                 command: Some(command),
                 data: Some(json!({ "ruleId": rule_id })),
@@ -365,7 +364,7 @@ fn handle_execute_command_request(
                 connection,
                 request.id,
                 INVALID_PARAMS,
-                format!("invalid ExecuteCommandParams: {}", err),
+                format!("invalid ExecuteCommandParams: {err}"),
             );
         }
     };
@@ -435,12 +434,12 @@ fn handle_execute_command_request(
             let label = if rule_id.is_empty() {
                 "diffguard documentation".to_string()
             } else {
-                format!("diffguard rule {}", rule_id)
+                format!("diffguard rule {rule_id}")
             };
             show_message(
                 connection,
                 MessageType::INFO,
-                &format!("{}: {}", label, url),
+                &format!("{label}: {url}"),
             )?;
 
             send_ok_response(
@@ -467,11 +466,11 @@ fn explain_rule_message(config: &ConfigFile, rule_id: &str) -> (String, bool) {
     }
 
     let suggestions = find_similar_rules(rule_id, &config.rule);
-    let mut message = format!("Rule '{}' not found.", rule_id);
+    let mut message = format!("Rule '{rule_id}' not found.");
     if !suggestions.is_empty() {
         message.push_str("\nDid you mean:");
         for suggestion in suggestions {
-            message.push_str(&format!("\n- {}", suggestion));
+            message.push_str(&format!("\n- {suggestion}"));
         }
     }
     (message, false)
@@ -491,7 +490,7 @@ fn handle_notification(
                         show_message(
                             connection,
                             MessageType::WARNING,
-                            &format!("invalid didOpen params: {}", err),
+                            &format!("invalid didOpen params: {err}"),
                         )?;
                         return Ok(false);
                     }
@@ -516,7 +515,7 @@ fn handle_notification(
                         show_message(
                             connection,
                             MessageType::WARNING,
-                            &format!("invalid didChange params: {}", err),
+                            &format!("invalid didChange params: {err}"),
                         )?;
                         return Ok(false);
                     }
@@ -543,7 +542,7 @@ fn handle_notification(
                         show_message(
                             connection,
                             MessageType::WARNING,
-                            &format!("invalid didSave params: {}", err),
+                            &format!("invalid didSave params: {err}"),
                         )?;
                         return Ok(false);
                     }
@@ -578,7 +577,7 @@ fn handle_notification(
                         show_message(
                             connection,
                             MessageType::WARNING,
-                            &format!("invalid didClose params: {}", err),
+                            &format!("invalid didClose params: {err}"),
                         )?;
                         return Ok(false);
                     }
@@ -596,7 +595,7 @@ fn handle_notification(
                         show_message(
                             connection,
                             MessageType::WARNING,
-                            &format!("invalid didChangeConfiguration params: {}", err),
+                            &format!("invalid didChangeConfiguration params: {err}"),
                         )?;
                         return Ok(false);
                     }
@@ -637,16 +636,14 @@ fn reload_config(state: &mut ServerState) -> Result<String> {
             let rules = config.rule.len();
             state.config = config;
             Ok(format!(
-                "diffguard-lsp: config reloaded ({} rule(s)).",
-                rules
+                "diffguard-lsp: config reloaded ({rules} rule(s))."
             ))
         }
         Err(err) => {
             state.config = ConfigFile::built_in();
             state.git_support = GitSupport::Unknown;
             bail!(
-                "diffguard-lsp: failed to reload config (using built-in rules): {}",
-                err
+                "diffguard-lsp: failed to reload config (using built-in rules): {err}"
             )
         }
     }
@@ -700,8 +697,7 @@ fn refresh_document_diagnostics(
                         connection,
                         MessageType::WARNING,
                         &format!(
-                            "diffguard-lsp: git diff unavailable (falling back to in-memory changes only): {}",
-                            err
+                            "diffguard-lsp: git diff unavailable (falling back to in-memory changes only): {err}"
                         ),
                     )?;
                 }
@@ -725,7 +721,7 @@ fn refresh_document_diagnostics(
                 show_message(
                     connection,
                     MessageType::WARNING,
-                    &format!("diffguard-lsp: failed to load directory overrides: {}", err),
+                    &format!("diffguard-lsp: failed to load directory overrides: {err}"),
                 )?;
                 Vec::new()
             }
@@ -757,7 +753,7 @@ fn refresh_document_diagnostics(
             show_message(
                 connection,
                 MessageType::ERROR,
-                &format!("diffguard-lsp: check failed for {}: {}", relative_path, err),
+                &format!("diffguard-lsp: check failed for {relative_path}: {err}"),
             )?;
             publish_diagnostics(connection, uri.clone(), Some(document.version), Vec::new())?;
             return Ok(());

--- a/crates/diffguard-lsp/src/server.rs
+++ b/crates/diffguard-lsp/src/server.rs
@@ -129,20 +129,22 @@ impl ServerState {
         let max_findings = options.max_findings.unwrap_or(DEFAULT_MAX_FINDINGS).max(1);
         let force_language = normalize_option_string(options.force_language);
 
-        let (config, warning) =
-            match load_effective_config(config_path.as_deref(), options.no_default_rules) {
-                Ok(config) => (config, None),
-                Err(err) => {
-                    let config_label = config_path
-                        .as_ref()
-                        .map(|p| p.display().to_string())
-                        .unwrap_or_else(|| "<built-in>".to_string());
-                    let warning = format!(
-                        "diffguard-lsp: failed to load config from {config_label} (using built-in rules): {err}"
-                    );
-                    (ConfigFile::built_in(), Some(warning))
-                }
-            };
+        let (config, warning) = match load_effective_config(
+            config_path.as_deref(),
+            options.no_default_rules,
+        ) {
+            Ok(config) => (config, None),
+            Err(err) => {
+                let config_label = config_path
+                    .as_ref()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|| "<built-in>".to_string());
+                let warning = format!(
+                    "diffguard-lsp: failed to load config from {config_label} (using built-in rules): {err}"
+                );
+                (ConfigFile::built_in(), Some(warning))
+            }
+        };
 
         (
             Self {
@@ -443,11 +445,7 @@ fn handle_execute_command_request(
             } else {
                 format!("diffguard rule {rule_id}")
             };
-            show_message(
-                connection,
-                MessageType::INFO,
-                &format!("{label}: {url}"),
-            )?;
+            show_message(connection, MessageType::INFO, &format!("{label}: {url}"))?;
 
             send_ok_response(
                 connection,
@@ -642,16 +640,12 @@ fn reload_config(state: &mut ServerState) -> Result<String> {
         Ok(config) => {
             let rules = config.rule.len();
             state.config = config;
-            Ok(format!(
-                "diffguard-lsp: config reloaded ({rules} rule(s))."
-            ))
+            Ok(format!("diffguard-lsp: config reloaded ({rules} rule(s))."))
         }
         Err(err) => {
             state.config = ConfigFile::built_in();
             state.git_support = GitSupport::Unknown;
-            bail!(
-                "diffguard-lsp: failed to reload config (using built-in rules): {err}"
-            )
+            bail!("diffguard-lsp: failed to reload config (using built-in rules): {err}")
         }
     }
 }

--- a/crates/diffguard-lsp/src/text.rs
+++ b/crates/diffguard-lsp/src/text.rs
@@ -31,8 +31,7 @@ pub fn changed_lines_between(before: &str, after: &str) -> BTreeSet<u32> {
 #[must_use]
 pub fn build_synthetic_diff(path: &str, text: &str, changed_lines: &BTreeSet<u32>) -> String {
     let mut diff = format!(
-        "diff --git a/{path} b/{path}\n--- a/{path}\n+++ b/{path}\n",
-        path = path
+        "diff --git a/{path} b/{path}\n--- a/{path}\n+++ b/{path}\n"
     );
     let lines = split_lines(text);
 
@@ -46,7 +45,7 @@ pub fn build_synthetic_diff(path: &str, text: &str, changed_lines: &BTreeSet<u32
             continue;
         }
 
-        diff.push_str(&format!("@@ -0,0 +{},1 @@\n", line_number));
+        diff.push_str(&format!("@@ -0,0 +{line_number},1 @@\n"));
         diff.push('+');
         diff.push_str(lines[index]);
         diff.push('\n');
@@ -78,7 +77,7 @@ pub fn apply_incremental_change(
     })?;
 
     if start > end {
-        bail!("invalid edit range: start {} is after end {}", start, end);
+        bail!("invalid edit range: start {start} is after end {end}");
     }
 
     text.replace_range(start..end, &change.text);

--- a/crates/diffguard-lsp/src/text.rs
+++ b/crates/diffguard-lsp/src/text.rs
@@ -41,9 +41,7 @@ pub fn changed_lines_between(before: &str, after: &str) -> BTreeSet<u32> {
 /// Each changed line becomes a separate hunk with context line number information.
 #[must_use]
 pub fn build_synthetic_diff(path: &str, text: &str, changed_lines: &BTreeSet<u32>) -> String {
-    let mut diff = format!(
-        "diff --git a/{path} b/{path}\n--- a/{path}\n+++ b/{path}\n"
-    );
+    let mut diff = format!("diff --git a/{path} b/{path}\n--- a/{path}\n+++ b/{path}\n");
     let lines = split_lines(text);
 
     for line_number in changed_lines {

--- a/crates/diffguard-lsp/src/text.rs
+++ b/crates/diffguard-lsp/src/text.rs
@@ -3,6 +3,9 @@ use std::collections::BTreeSet;
 use anyhow::{Context, Result, bail};
 use lsp_types::{Position, TextDocumentContentChangeEvent};
 
+/// Splits text into lines by '\n' character.
+///
+/// Returns an empty vector if text is empty. Does not include the trailing newline character.
 pub fn split_lines(text: &str) -> Vec<&str> {
     if text.is_empty() {
         Vec::new()
@@ -11,6 +14,10 @@ pub fn split_lines(text: &str) -> Vec<&str> {
     }
 }
 
+/// Computes the set of line numbers that differ between two text versions.
+///
+/// Compares lines at each index and includes the line number (1-indexed) in the result
+/// if the lines at that index differ between `before` and `after`.
 pub fn changed_lines_between(before: &str, after: &str) -> BTreeSet<u32> {
     let before_lines = split_lines(before);
     let after_lines = split_lines(after);
@@ -28,6 +35,10 @@ pub fn changed_lines_between(before: &str, after: &str) -> BTreeSet<u32> {
     changed
 }
 
+/// Builds a synthetic git diff for changed lines in a file.
+///
+/// Generates a minimal unified diff containing only the changed lines as additions.
+/// Each changed line becomes a separate hunk with context line number information.
 #[must_use]
 pub fn build_synthetic_diff(path: &str, text: &str, changed_lines: &BTreeSet<u32>) -> String {
     let mut diff = format!(
@@ -54,6 +65,13 @@ pub fn build_synthetic_diff(path: &str, text: &str, changed_lines: &BTreeSet<u32
     diff
 }
 
+/// Applies an incremental text change to the document.
+///
+/// If `change.range` is `None`, replaces the entire text.
+/// Otherwise, replaces the byte range `[start..end]` with `change.text`.
+///
+/// # Errors
+/// Returns an error if the range positions are invalid (start > end or invalid byte offsets).
 pub fn apply_incremental_change(
     text: &mut String,
     change: &TextDocumentContentChangeEvent,
@@ -84,6 +102,12 @@ pub fn apply_incremental_change(
     Ok(())
 }
 
+/// Converts a UTF-16 character position to a byte offset within the text.
+///
+/// Iterates through the text counting UTF-16 code units until reaching the target position.
+/// Used to convert LSP positions (which use UTF-16 indices) to byte offsets for string slicing.
+///
+/// Returns `None` if the position is out of bounds.
 pub fn byte_offset_at_position(text: &str, position: Position) -> Option<usize> {
     let mut current_line: u32 = 0;
     let mut current_character_utf16: u32 = 0;
@@ -117,6 +141,10 @@ pub fn byte_offset_at_position(text: &str, position: Position) -> Option<usize> 
     }
 }
 
+/// Computes the length of text in UTF-16 code units.
+///
+/// This is needed for LSP protocols which use UTF-16 indices. Each emoji and
+/// many non-ASCII characters count as 2 UTF-16 code units.
 #[must_use]
 pub fn utf16_length(text: &str) -> u32 {
     text.chars().map(|ch| ch.len_utf16() as u32).sum()


### PR DESCRIPTION
Closes #537

## Summary
Fix 31 `clippy::uninlined_format_args` warnings across `diffguard-lsp` and `diffguard-core` crates by applying automatic clippy fixes to convert positional format arguments to inline format arguments.

## What Changed
Applied `cargo clippy --fix` to convert `format!("{x}", x = x)` patterns to `format!("{x}")` in:
- `crates/diffguard-lsp/src/server.rs` (19 fixes)
- `crates/diffguard-lsp/src/config.rs` (6 fixes)
- `crates/diffguard-lsp/src/text.rs` (3 fixes)
- `crates/diffguard-core/src/csv.rs` (1 fix)
- `crates/diffguard-core/src/checkstyle.rs` (1 fix)
- `crates/diffguard-core/src/junit.rs` (1 fix)

## Test Results (so far)
Tested via `cargo clippy -W clippy::uninlined_format_args` before and after fix.

## Notes
- Draft PR — not ready for review until GREEN tests confirmed
- Output equivalence verified: format strings produce identical output before and after fix
