### PR TITLE
Use clone_from instead of redundant clone

### DIFF
--- a/crates/diffguard-analytics/src/lib.rs
+++ b/crates/diffguard-analytics/src/lib.rs
@@ -118,7 +118,7 @@ pub fn merge_false_positive_baselines(
         {
             // Preserve manually curated metadata from the existing baseline.
             if existing.note.is_none() && entry.note.is_some() {
-                existing.note = entry.note.clone();
+                existing.note.clone_from(&entry.note);
             }
             if existing.rule_id.is_empty() {
                 existing.rule_id.clone_from(&entry.rule_id);

--- a/crates/diffguard-analytics/src/lib.rs
+++ b/crates/diffguard-analytics/src/lib.rs
@@ -121,10 +121,10 @@ pub fn merge_false_positive_baselines(
                 existing.note = entry.note.clone();
             }
             if existing.rule_id.is_empty() {
-                existing.rule_id = entry.rule_id.clone();
+                existing.rule_id.clone_from(&entry.rule_id);
             }
             if existing.path.is_empty() {
-                existing.path = entry.path.clone();
+                existing.path.clone_from(&entry.path);
             }
             if existing.line == 0 {
                 existing.line = entry.line;


### PR DESCRIPTION
Replaced redundant clone() calls with clone_from() where applicable to avoid unnecessary allocations.

Fixes #1046