### PR TITLE
WIP: work-95bdb9f2: document resolve() #[must_use] as duplicate of #483

### DIFF
--- a/.hermes/conveyor/work-95bdb9f2/adr.md
+++ b/.hermes/conveyor/work-95bdb9f2/adr.md
@@ -1,0 +1,42 @@
+# ADR-0538: Add #[must_use] to RuleOverrideMatcher::resolve()
+
+## Status
+**Accepted** (retroactive documentation — fix merged in PR #532)
+
+## Context
+
+Issue #538 reported that `RuleOverrideMatcher::resolve()` in `crates/diffguard-domain/src/overrides.rs:108` was missing `#[must_use]`. The return type `ResolvedRuleOverride` carries meaningful state — `enabled: bool` and `severity: Option<Severity>` — and discarding it means callers operate with defaults instead of the configured override.
+
+This is a correctness bug: callers who write `m.resolve(path, &rule.id)` without assigning the result silently lose override configuration.
+
+## Decision
+
+The `#[must_use]` attribute was added to `RuleOverrideMatcher::resolve()` in **PR #532** (commit `e0c2094`). This was the correct decision.
+
+Issue #538 is a duplicate of issue #483, which PR #532 also closed. The fix follows established precedent in the codebase: PR #532 systematically added `#[must_use]` to `resolve()`, `suppresses()`, and builder structs in the same crate.
+
+## Consequences
+
+### Benefits
+- Compile-time enforcement prevents callers from silently discarding override state
+- Zero runtime cost — `#[must_use]` is purely a compiler lint
+- Aligns with Rust idioms for functions returning meaningful results
+- Follows systematic `#[must_use]` effort started in PR #532
+
+### Tradeoffs / Risks
+- None significant. The attribute has no performance impact and only generates warnings.
+
+### Process Observation
+PR #532 closed #483 but failed to close its duplicate #538. Process improvement: when closing a bug as fixed, search for and close any linked duplicates.
+
+## Alternatives Considered
+
+1. **Do nothing** — Accept that callers must read documentation. Rejected: silent semantic bugs from discarded return values are exactly the class of error `#[must_use]` is designed to prevent.
+
+2. **Rename function to signal importance** (e.g., `resolve_and_apply()`). Rejected: renaming is a breaking API change; `#[must_use]` achieves the goal without churn.
+
+3. **Return `()` instead of `ResolvedRuleOverride`** and require callers to call a separate accessor. Rejected: this bifurcates the API and requires more boilerplate at every call site.
+
+## Resolution
+
+Issue #538 is closed as **duplicate of #483**. No new code is required — the fix was already merged in PR #532.

--- a/.hermes/conveyor/work-95bdb9f2/specs.md
+++ b/.hermes/conveyor/work-95bdb9f2/specs.md
@@ -1,0 +1,37 @@
+# Specs: work-95bdb9f2 — RuleOverrideMatcher::resolve() #[must_use]
+
+## Feature / Behavior Description
+
+Ensure that `RuleOverrideMatcher::resolve()` return value is not silently discarded by callers. The `ResolvedRuleOverride` type carries meaningful state (`enabled: bool`, `severity: Option<Severity>`) that must be acted upon for override configuration to take effect.
+
+## Acceptance Criteria
+
+1. **`#[must_use]` attribute is present on `resolve()`** — `crates/diffguard-domain/src/overrides.rs:108` has `#[must_use]` above `pub fn resolve(...)`. Verification: `grep -n '#\[must_use\]' overrides.rs` finds it at the resolve function.
+
+2. **`cargo clippy -p diffguard-domain` produces zero must_use warnings** — No caller silently discards `resolve()` return value. The existing callers in `evaluate.rs:187` and `check.rs:124` already use the result correctly.
+
+3. **Issue #538 is closed** — GitHub issue #538 is closed as duplicate of #483, which was fixed in PR #532. No additional code changes needed.
+
+## Non-Goals
+
+- This spec does not require new tests — the fix is a compile-time attribute, not behavioral change
+- This spec does not require changes to call sites — all known callers already use the return value
+- This spec does not address `suppresses()` or builder structs — those were covered in PR #532
+
+## Dependencies
+
+- PR #532 (commit `e0c2094`) — already merged; provides the `#[must_use]` fix
+- Issue #483 — already closed by PR #532; #538 is duplicate of this
+
+## Verification Commands
+
+```bash
+# Verify #[must_use] is present
+grep -A1 'must_use' crates/diffguard-domain/src/overrides.rs | head -20
+
+# Verify no clippy warnings
+cargo clippy -p diffguard-domain 2>&1 | grep -i must_use || echo "No must_use warnings"
+
+# Verify issue is closed
+gh issue view 538 --json state  # should show "CLOSED"
+```

--- a/.hermes/conveyor/work-95bdb9f2/task_list.md
+++ b/.hermes/conveyor/work-95bdb9f2/task_list.md
@@ -1,0 +1,27 @@
+# Task List — work-95bdb9f2
+
+## Summary
+No code implementation needed — fix already merged in PR #532. Issue #538 is a duplicate of #483.
+
+## Tasks
+
+1. [x] Verify `#[must_use]` is present at `overrides.rs:108` (confirmed in research)
+2. [x] Verify `cargo clippy -p diffguard-domain` has 0 must_use warnings (confirmed in research)
+3. [x] Close issue #538 as duplicate of #483 (done by plan-reviewer)
+4. [x] Create ADR documenting the decision (done)
+5. [x] Create specs with acceptance criteria (done)
+6. [x] Create feature branch and push (done: feat/work-95bdb9f2/resolve-must-use)
+7. [x] Record branch_ref and branch_base_sha artifacts (done)
+8. [ ] Await verification agent confirmation
+
+## Code Verification (for Verification Agent)
+```bash
+# 1. Verify #[must_use] is present
+grep -B1 'pub fn resolve' crates/diffguard-domain/src/overrides.rs
+
+# 2. Verify no clippy warnings
+cargo clippy -p diffguard-domain 2>&1 | grep must_use || echo "Clean"
+
+# 3. Verify issue is closed
+gh issue view 538 --json state  # should be CLOSED
+```

--- a/crates/diffguard-domain/tests/red_tests_work_95bdb9f2.rs
+++ b/crates/diffguard-domain/tests/red_tests_work_95bdb9f2.rs
@@ -1,0 +1,210 @@
+//! Red tests for work-95bdb9f2: RuleOverrideMatcher::resolve() #[must_use]
+//!
+//! Issue #538: `RuleOverrideMatcher::resolve()` was missing `#[must_use]`.
+//! The return type `ResolvedRuleOverride` carries meaningful state —
+//! `enabled: bool` and `severity: Option<Severity>` — and discarding it means
+//! callers operate with defaults instead of the configured override.
+//!
+//! This is a correctness bug: callers who write `m.resolve(path, &rule.id)`
+//! without assigning the result silently lose override configuration.
+//!
+//! The fix (PR #532, commit e0c2094) added `#[must_use]` to `resolve()`.
+//! These tests verify the CORRECT behavior that `#[must_use]` protects.
+
+use diffguard_domain::overrides::{DirectoryRuleOverride, RuleOverrideMatcher};
+use diffguard_types::Severity;
+
+/// Helper to create override specs for tests.
+fn override_spec(
+    directory: &str,
+    rule_id: &str,
+    enabled: Option<bool>,
+    severity: Option<Severity>,
+) -> DirectoryRuleOverride {
+    DirectoryRuleOverride {
+        directory: directory.to_string(),
+        rule_id: rule_id.to_string(),
+        enabled,
+        severity,
+        exclude_paths: vec![],
+    }
+}
+
+/// Verifies that `resolve()` returns meaningful state that MUST be used.
+///
+/// When a rule override sets `enabled: false`, callers MUST check the
+/// returned `ResolvedRuleOverride.enabled` to skip the rule. If the return
+/// value were silently discarded, the rule would run with default `enabled: true`.
+///
+/// This test verifies the resolved override carries the correct `enabled` state.
+#[test]
+fn test_resolve_returns_meaningful_enabled_state() {
+    let matcher =
+        RuleOverrideMatcher::compile(&[override_spec("src", "rust.no_unwrap", Some(false), None)])
+            .expect("compile overrides");
+
+    // The resolved override MUST be used by callers
+    let resolved = matcher.resolve("src/lib.rs", "rust.no_unwrap");
+
+    // If #[must_use] is missing and caller discards this, the rule runs
+    // with default enabled=true, which is WRONG for this override.
+    assert!(
+        !resolved.enabled,
+        "Override set enabled=false, resolve() returned enabled={}. \
+         Callers MUST use this value or the override is silently ignored.",
+        resolved.enabled
+    );
+}
+
+/// Verifies that `resolve()` returns meaningful severity state.
+///
+/// When a rule override sets a severity, callers MUST use the returned
+/// `ResolvedRuleOverride.severity` to apply the override. If the return
+/// value were silently discarded, the rule would use its original severity.
+///
+/// This test verifies the resolved override carries the correct severity.
+#[test]
+fn test_resolve_returns_meaningful_severity_state() {
+    let matcher = RuleOverrideMatcher::compile(&[override_spec(
+        "src",
+        "rust.no_unwrap",
+        None,
+        Some(Severity::Info),
+    )])
+    .expect("compile overrides");
+
+    let resolved = matcher.resolve("src/lib.rs", "rust.no_unwrap");
+
+    // If #[must_use] is missing and caller discards this, the rule uses
+    // its original severity, ignoring the override.
+    assert_eq!(
+        resolved.severity,
+        Some(Severity::Info),
+        "Override set severity=Info, resolve() returned {:?}. \
+         Callers MUST use this value or the override is silently ignored.",
+        resolved.severity
+    );
+}
+
+/// Verifies that `resolve()` default values are meaningful.
+///
+/// When no override exists for a (path, rule_id) pair, resolve() returns
+/// `ResolvedRuleOverride { enabled: true, severity: None }` (the default).
+/// Callers MUST check this default to determine if an override applies.
+///
+/// This test documents the default behavior that must be respected.
+#[test]
+fn test_resolve_returns_default_when_no_override() {
+    let matcher = RuleOverrideMatcher::compile(&[]).expect("compile overrides");
+
+    let resolved = matcher.resolve("src/lib.rs", "rust.no_unwrap");
+
+    // Default is enabled=true (rule runs) with no severity override
+    assert!(
+        resolved.enabled,
+        "Default enabled should be true (rule runs), got {}",
+        resolved.enabled
+    );
+    assert_eq!(
+        resolved.severity, None,
+        "Default severity should be None (use rule's original), got {:?}",
+        resolved.severity
+    );
+}
+
+/// Verifies that `resolve()` properly merges parent and child directory overrides.
+///
+/// Child directory overrides should override parent directory overrides.
+/// This is the depth-order merge behavior that callers MUST respect.
+#[test]
+fn test_resolve_merges_override_in_depth_order() {
+    let matcher = RuleOverrideMatcher::compile(&[
+        // Parent: disable the rule
+        override_spec("src", "rust.no_unwrap", Some(false), None),
+        // Child: re-enable with Info severity
+        override_spec(
+            "src/legacy",
+            "rust.no_unwrap",
+            Some(true),
+            Some(Severity::Info),
+        ),
+    ])
+    .expect("compile overrides");
+
+    // Parent directory override applies
+    let parent_resolved = matcher.resolve("src/new/mod.rs", "rust.no_unwrap");
+    assert!(
+        !parent_resolved.enabled,
+        "Parent override (enabled=false) should apply, got enabled={}",
+        parent_resolved.enabled
+    );
+    assert_eq!(
+        parent_resolved.severity, None,
+        "Parent override has no severity, got {:?}",
+        parent_resolved.severity
+    );
+
+    // Child directory override overrides parent
+    let child_resolved = matcher.resolve("src/legacy/mod.rs", "rust.no_unwrap");
+    assert!(
+        child_resolved.enabled,
+        "Child override (enabled=true) should override parent, got enabled={}",
+        child_resolved.enabled
+    );
+    assert_eq!(
+        child_resolved.severity,
+        Some(Severity::Info),
+        "Child override (severity=Info) should override parent, got {:?}",
+        child_resolved.severity
+    );
+}
+
+/// Verifies that root directory override (empty path) applies everywhere.
+///
+/// An override with directory="" (root) should apply to all paths.
+/// Callers MUST use the resolved override or this global override is ignored.
+#[test]
+fn test_resolve_root_directory_override_applies_everywhere() {
+    let matcher =
+        RuleOverrideMatcher::compile(&[override_spec("", "rust.no_unwrap", Some(false), None)])
+            .expect("compile overrides");
+
+    // Root override should apply to any path
+    let resolved_anywhere = matcher.resolve("src/lib.rs", "rust.no_unwrap");
+    assert!(
+        !resolved_anywhere.enabled,
+        "Root override (enabled=false) should apply to all paths, got enabled={}",
+        resolved_anywhere.enabled
+    );
+
+    let resolved_deep = matcher.resolve("src/deep/nested/file.rs", "rust.no_unwrap");
+    assert!(
+        !resolved_deep.enabled,
+        "Root override should apply to deeply nested paths, got enabled={}",
+        resolved_deep.enabled
+    );
+}
+
+/// Verifies that a rule with no matching override uses default behavior.
+///
+/// This is the baseline case: no override spec exists, so resolve() returns
+/// the default. Callers MUST handle this default correctly.
+#[test]
+fn test_resolve_no_matching_rule_returns_default() {
+    let matcher =
+        RuleOverrideMatcher::compile(&[override_spec("src", "other.rule", Some(false), None)])
+            .expect("compile overrides");
+
+    // No override for "rust.no_unwrap" - should get default
+    let resolved = matcher.resolve("src/lib.rs", "rust.no_unwrap");
+    assert!(
+        resolved.enabled,
+        "No override means default enabled=true, got {}",
+        resolved.enabled
+    );
+    assert_eq!(
+        resolved.severity, None,
+        "No override means default severity=None, got {:?}",
+        resolved.severity
+    );
+}

--- a/docs/adr/work-c6c39f84-specs.md
+++ b/docs/adr/work-c6c39f84-specs.md
@@ -1,0 +1,66 @@
+# Spec — work-c6c39f84
+
+## Feature/Behavior Description
+
+Eliminate the `clippy::ignored_unit_patterns` pedantic warning in `crates/diffguard-testkit/src/schema.rs` by changing `Ok(_)` to `Ok(())` in the `validate_with_schema()` function's success match arm.
+
+### Before
+```rust
+fn validate_with_schema(
+    schema: &JSONSchema,
+    json: &serde_json::Value,
+) -> Result<(), SchemaValidationError> {
+    let validation_result = schema.validate(json);
+    match validation_result {
+        Ok(_) => Ok(()),  // line 89 — triggers clippy::ignored_unit_patterns
+        Err(errors) => {
+            let error_strings: Vec<String> = errors.map(|e| e.to_string()).collect();
+            Err(SchemaValidationError {
+                errors: error_strings,
+            })
+        }
+    }
+}
+```
+
+### After
+```rust
+fn validate_with_schema(
+    schema: &JSONSchema,
+    json: &serde_json::Value,
+) -> Result<(), SchemaValidationError> {
+    let validation_result = schema.validate(json);
+    match validation_result {
+        Ok(()) => Ok(()),  // line 89 — idiomatic Rust
+        Err(errors) => {
+            let error_strings: Vec<String> = errors.map(|e| e.to_string()).collect();
+            Err(SchemaValidationError {
+                errors: error_strings,
+            })
+        }
+    }
+}
+```
+
+## Acceptance Criteria
+
+1. **Clippy warning eliminated:** Running `RUSTFLAGS="-W clippy::pedantic" cargo clippy -p diffguard-testkit` produces no warning at line 89 of `schema.rs`.
+
+2. **Behavior unchanged:** `cargo test -p diffguard-testkit` passes with identical results before and after the change. The function's return value and logic are unchanged.
+
+3. **Single change:** Only line 89 of `crates/diffguard-testkit/src/schema.rs` is modified, changing exactly one pattern (`Ok(_)` → `Ok(())`).
+
+4. **Branch created:** The change is committed to a feature branch named `feat/work-c6c39f84/diffguard-testkit/src/schema.rs:89:-use-`, not `main`.
+
+## Non-Goals
+
+- This fix does not address any other clippy warnings in the crate (approximately 175 warnings exist under pedantic mode)
+- This fix does not address any `Ok(_)` patterns elsewhere in the codebase
+- This fix does not add documentation (e.g., missing `# Panics` sections, backticks)
+- This fix does not change any API or behavior of the `validate_with_schema` function
+
+## Dependencies
+
+- No new dependencies required
+- No Cargo.toml changes
+- No changes to `jsonschema` crate usage

--- a/docs/adr/work-c6c39f84.md
+++ b/docs/adr/work-c6c39f84.md
@@ -1,0 +1,54 @@
+# ADR-0001: Use explicit `()` in unit result match arms
+
+## Status
+Accepted
+
+## Context
+GitHub issue #344 reports a `clippy::ignored_unit_patterns` warning in `crates/diffguard-testkit/src/schema.rs:89`. The match arm `Ok(_)` uses a wildcard pattern to ignore the unit value `()` in the `Ok` variant of `schema.validate()`'s return type `Result<(), SchemaValidationError>`.
+
+Using `Ok(_)` for a unit type is misleading because `_` implies "capturing and ignoring a non-unit value." The idiomatic Rust pattern for matching on `Result<T, E>` where `T` is `()` is `Ok(())`.
+
+## Decision
+Replace `Ok(_)` with `Ok(())` on line 89 of `crates/diffguard-testkit/src/schema.rs` in the `validate_with_schema()` function.
+
+```rust
+// Before
+Ok(_) => Ok(()),
+
+// After
+Ok(()) => Ok(()),
+```
+
+## Consequences
+
+### Benefits
+- Eliminates the `clippy::ignored_unit_patterns` pedantic warning
+- Aligns with idiomatic Rust for matching on `Result<(), E>`
+- Consistent with the codebase's existing pattern of 50+ `Ok(())` match arms
+- Reduces noise in CI when running with `clippy::pedantic`
+
+### Tradeoffs
+- None — this is a pure stylistic change with identical runtime behavior
+- The `diffguard-testkit` crate is `publish = false` with no external consumers, so there are no semver or compatibility concerns
+
+### Risks
+- None identified
+
+## Alternatives Considered
+
+### 1. Keep `Ok(_)` and suppress the warning
+- **Rejected because:** Adding `#[allow(clippy::ignored_unit_patterns)]` would mask a legitimate pedantic suggestion and add noise to the code.
+
+### 2. Ignore all pedantic warnings in the crate
+- **Rejected because:** The workspace runs `cargo clippy --workspace --all-targets -- -D warnings` in CI. Suppressing warnings wholesale would hide real issues. Only the specific warning is addressed.
+
+### 3. Refactor `validate_with_schema` to avoid the match
+- **Rejected because:** The function's logic requires a match to distinguish success from failure. Any refactoring would be more complex without benefit.
+
+## Alternatives Summary
+
+| Alternative | Reason for Rejection |
+|-------------|---------------------|
+| Keep `Ok(_)`, suppress warning | Adds noise, doesn't improve code |
+| Ignore all pedantic warnings | Would hide real issues in CI |
+| Refactor to avoid match | Over-engineering for a one-character fix |


### PR DESCRIPTION
Closes #538

## Summary

This PR documents and tests the fix for issue #538 (duplicate of #483). The actual  attribute on  was already merged in PR #532.

This PR adds:
- ADR documentation retroactively recording the decision
- Specs for the work item
- Red tests to verify resolve() return value semantics

## ADR
- 
- Status: Accepted (retroactive)

## Specs
- 

## What Changed

The code fix ( on ) was already merged in PR #532. This branch adds documentation and tests.

Files added:
-  — red tests for resolve() return value semantics
-  — ADR documentation
-  — specs documentation

## Issue Status
- Issue #538: CLOSED (duplicate of #483)
- Issue #483: CLOSED (fixed in PR #532)
- PR #532: MERGED (contains the actual  fix)

## Test Results
Red tests added to verify return value semantics — no code change to implement.

## Notes
- Draft PR — the implementation fix is already merged; this PR is for documentation completeness