### PR TITLE
WIP: deps: align bench proptest with workspace pin (1.5 → workspace)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal
 
 - **Extracted duplicated `escape_xml` function** from `checkstyle.rs` and `junit.rs` into shared `xml_utils.rs` module
+- **`bench` crate proptest alignment**: Changed `proptest = "1.5"` to `proptest.workspace = true` in `bench/Cargo.toml` dev-dependencies to align with workspace pinned version 1.10.0. Ensures benchmark property tests run against the same proptest version as the rest of the workspace.
 
 ## [0.2.0] - 2026-04-06
 

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -39,7 +39,7 @@ diffguard-core = { path = "../crates/diffguard-core", version = "0.2.0" }
 diffguard-types = { path = "../crates/diffguard-types", version = "0.2.0" }
 
 [dev-dependencies]
-proptest = "1.5"
+proptest.workspace = true
 diffguard-core = { path = "../crates/diffguard-core", version = "0.2.0" }
 diffguard-testkit = { path = "../crates/diffguard-testkit", version = "0.2.0" }
 insta.workspace = true


### PR DESCRIPTION
Closes #302

## Summary

Align bench/Cargo.toml dev-dependency proptest = 1.5 to use the workspace pinned version via proptest.workspace = true, matching the pattern used by all other workspace crates.

## ADR

- ADR: .hermes/conveyor/work-6cd3caee/adr.md

## Specs

- Specs: .hermes/conveyor/work-6cd3caee/specs.md

## What Changed

- bench/Cargo.toml: Changed proptest = 1.5 to proptest.workspace = true in dev-dependencies section

## Test Results (so far)

Build and test verification was performed by the code-builder agent.

## Notes

- Draft PR — not ready for review until GREEN tests confirmed