### PR TITLE
ci(codecov): add advisory coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,128 @@
+name: Coverage
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - "bench/**"
+      - "xtask/**"
+      - ".github/workflows/coverage.yml"
+      - "codecov.yml"
+      - "docs/ci/coverage.md"
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - "bench/**"
+      - "xtask/**"
+      - ".github/workflows/coverage.yml"
+      - "codecov.yml"
+      - "docs/ci/coverage.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coverage-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  RUSTFLAGS: "-C debuginfo=0"
+
+jobs:
+  coverage:
+    name: Codecov Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci') ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full')
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.92"
+          components: llvm-tools-preview
+      - name: Use larger target dir
+        run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/target" >> "$GITHUB_ENV"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-directories: ${{ runner.temp }}/target
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: Generate coverage
+        env:
+          CI: true
+          INSTA_UPDATE: "no"
+          PROPTEST_CASES: "100"
+        run: |
+          set -euo pipefail
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov test \
+            --workspace \
+            --locked \
+            --all-features \
+            --no-report
+          cargo llvm-cov report --json --output-path coverage.json
+          cargo llvm-cov report --lcov --output-path lcov.info
+          cargo llvm-cov report --text | tee coverage.txt
+      - name: Validate coverage output
+        run: |
+          set -euo pipefail
+          test -s coverage.json
+          test -s coverage.txt
+          test -s lcov.info
+      - name: Detect Codecov token
+        id: codecov-token
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          if [ -n "${CODECOV_TOKEN:-}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Upload coverage to Codecov (main)
+        if: ${{ always() && github.event_name == 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-core
+          name: diffguard-rust-core
+          fail_ci_if_error: true
+      - name: Upload coverage to Codecov (advisory)
+        if: ${{ always() && github.event_name != 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-core
+          name: diffguard-rust-core
+          fail_ci_if_error: false
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage.json
+            coverage.txt
+            lcov.info
+          retention-days: 14


### PR DESCRIPTION
## Summary
Adds step 1 of the diffguard Codecov rollout: an advisory `cargo-llvm-cov` coverage workflow that generates reports and conditionally uploads to Codecov.

## CI economics
- **Default PR LEM impact:** Minimal when not labeled; zero when not triggered.
- **Workflow touched:** New `.github/workflows/coverage.yml` only; does not modify `ci.yml`.
- **Branch protection impact:** None; coverage is advisory, not required.
- **Failure mode caught:** Missing coverage artifacts or upload token detection issues.
- **Cheaper signal considered:** Coverage is already run by tests; this workflow reruns tests instrumented for coverage, which is necessary for accurate upload.
- **Rollback path:** Delete `.github/workflows/coverage.yml` and any runs; no config or badge dependencies yet.

## Claim boundary
Codecov coverage is Rust execution-surface evidence only. It does **not** prove:
- diff parser correctness
- rule evaluation correctness
- inline suppression correctness
- renderer completeness (SARIF, JUnit, Checkstyle, GitLab, etc.)
- LSP diagnostic correctness
- false-positive baseline or trend correctness
- mutation adequacy
- fuzz robustness
- release readiness

Those are separate proof lanes (test, golden, conformance, fuzz, mutation).

## Validation
- [x] workflow syntax is valid YAML
- [x] paths trigger correctly (Cargo.toml, crates/**, xtask/**, .github/workflows/coverage.yml, codecov.yml, docs/ci/coverage.md)
- [x] coverage job only runs on push, workflow_dispatch, or labeled PRs
- [x] token detection is conditional; workflow succeeds even without CODECOV_TOKEN
- [x] main uploads are hard-fail; PR uploads are soft-fail
- [x] artifacts are uploaded for 14 days with clear names

---
_Generated by [Claude Code](https://claude.ai/code/session_01VboXJ243Rjf8hJFzcdVJWE)_