### PR TITLE
ci(codecov): add quiet Codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...85"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+        informational: true
+        flags:
+          - rust-core
+    patch:
+      default:
+        target: 70%
+        threshold: 20%
+        informational: true
+        flags:
+          - rust-core
+
+comment: false
+github_checks:
+  annotations: false
+
+ignore:
+  - "target/**"
+  - "bench/**"
+  - "crates/*/benches/**"
+  - "crates/*/examples/**"


### PR DESCRIPTION
## Summary
Adds step 2 of the diffguard Codecov rollout: `codecov.yml` with advisory statuses and disabled comments for quiet operation.

## CI economics
- **Default PR LEM impact:** None; configuration file only.
- **Workflow touched:** None; this is a configuration file for the Codecov service.
- **Branch protection impact:** None; all statuses are informational (threshold applied but do not block).
- **Failure mode caught:** None directly; this is configuration that enables the coverage workflow from PR 1 to report.
- **Cheaper signal considered:** Configuration is static YAML; no cheaper signal available.
- **Rollback path:** Delete `codecov.yml` and coverage.yml workflow will still generate and upload artifacts; Codecov service defaults apply.

## Claim boundary
Codecov coverage is Rust execution-surface evidence only. It does **not** prove:
- diff parser correctness
- rule evaluation correctness
- inline suppression correctness
- renderer completeness (SARIF, JUnit, Checkstyle, GitLab, etc.)
- LSP diagnostic correctness
- false-positive baseline or trend correctness
- mutation adequacy
- fuzz robustness
- release readiness

Those are separate proof lanes (test, golden, conformance, fuzz, mutation).

## Configuration highlights
- **Project coverage:** Auto target with 5% threshold (informational)
- **Patch coverage:** 70% target with 20% threshold (informational)
- **Comments:** Disabled (no commit comments from Codecov)
- **Annotations:** Disabled (no GitHub check annotations)
- **Precision:** 2 decimal places, round down
- **Flags:** `rust-core` to track Rust execution surface
- **Ignores:** Benchmarks, examples, and target directories

## Validation
- [x] codecov.yml is valid YAML
- [x] all status sections are informational (will not block)
- [x] comments and annotations are both disabled (quiet operation)
- [x] precision, range, and rounding are reasonable defaults
- [x] flag matches the workflow (rust-core)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VboXJ243Rjf8hJFzcdVJWE)_