### PR TITLE
docs(readme): add Codecov badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Crates.io](https://img.shields.io/crates/v/diffguard.svg)](https://crates.io/crates/diffguard)
 [![Documentation](https://docs.rs/diffguard/badge.svg)](https://docs.rs/diffguard)
 [![CI](https://github.com/effortlessmetrics/diffguard/actions/workflows/ci.yml/badge.svg)](https://github.com/effortlessmetrics/diffguard/actions/workflows/ci.yml)
+[![Coverage](https://github.com/EffortlessMetrics/diffguard/actions/workflows/coverage.yml/badge.svg?branch=main)](https://github.com/EffortlessMetrics/diffguard/actions/workflows/coverage.yml)
+[![Codecov](https://codecov.io/gh/EffortlessMetrics/diffguard/branch/main/graph/badge.svg)](https://codecov.io/gh/EffortlessMetrics/diffguard)
 [![License](https://img.shields.io/crates/l/diffguard.svg)](LICENSE-MIT)
 
 A diff-scoped governance linter: **rules applied to scoped lines** in a Git diff.


### PR DESCRIPTION
## Summary
Adds step 3 of the diffguard Codecov rollout: Coverage workflow and Codecov badges to the README badge block.

## CI economics
- **Default PR LEM impact:** None; documentation only.
- **Workflow touched:** None; badge block is documentation.
- **Branch protection impact:** None; badges are informational only.
- **Failure mode caught:** None; badges update passively as workflow runs complete.
- **Cheaper signal considered:** No cheaper way to signal coverage availability to users.
- **Rollback path:** Delete the two new badge lines from README.

## Claim boundary
Codecov coverage is Rust execution-surface evidence only. It does **not** prove:
- diff parser correctness
- rule evaluation correctness
- inline suppression correctness
- renderer completeness (SARIF, JUnit, Checkstyle, GitLab, etc.)
- LSP diagnostic correctness
- false-positive baseline or trend correctness
- mutation adequacy
- fuzz robustness
- release readiness

Those are separate proof lanes (test, golden, conformance, fuzz, mutation).

## Badges added
- **Coverage:** Points to the GitHub Actions coverage workflow runs on main
- **Codecov:** Points to the Codecov dashboard for branch=main

## Validation
- [x] badges follow the same style as existing badges
- [x] badge URLs are correct and target the right branches
- [x] no trailing whitespace or formatting issues

---
_Generated by [Claude Code](https://claude.ai/code/session_01VboXJ243Rjf8hJFzcdVJWE)_