### PR TITLE
docs(ci): document coverage lane

### DIFF
--- a/docs/ci/coverage.md
+++ b/docs/ci/coverage.md
@@ -1,0 +1,55 @@
+# Coverage
+
+Codecov coverage is Rust execution-surface evidence.
+
+## What it answers
+
+> Did tests execute this Rust surface?
+
+## What it does not answer
+
+- whether diff parsing is correct,
+- whether rule evaluation is correct,
+- whether inline suppressions are correct,
+- whether Markdown, SARIF, JUnit, Checkstyle, GitLab, CSV, TSV, or sensor rendering is complete,
+- whether LSP diagnostics and code actions are correct,
+- whether false-positive baselines or trend history are correct,
+- whether mutation adequacy is strong,
+- whether fuzzing is sufficient,
+- whether release readiness is proven.
+
+Those are separate proof lanes:
+- **Test**: unit, integration, golden, mutation, fuzz
+- **Conformance**: parser correctness, rule semantics, rendering completeness
+- **Golden**: expected input/output pairs for parser, rules, and renderers
+- **Mutation**: algorithmic adequacy under perturbation
+- **Fuzz**: robustness under random input
+
+## Execution surface
+
+The Coverage workflow runs on:
+- push to `main`,
+- `workflow_dispatch` (manual trigger),
+- PRs labeled `coverage`, `full-ci`, or `ci:full`.
+
+## Configuration
+
+Coverage is configured in `codecov.yml` with:
+- Project coverage target: auto with 5% threshold (informational only)
+- Patch coverage target: 70% with 20% threshold (informational only)
+- Codecov comments disabled
+- Codecov GitHub check annotations disabled
+
+## Artifacts
+
+Durable receipts are produced:
+- `coverage.json` — LLVM coverage report (JSON)
+- `coverage.txt` — LLVM coverage report (text)
+- `lcov.info` — LCOV coverage data
+- `target/coverage/coverage-receipt.json` — claim boundary receipt
+- GitHub Actions coverage artifact (stored for 14 days)
+- Codecov dashboard (if CODECOV_TOKEN is set)
+
+## Tool
+
+Coverage is collected by `cargo-llvm-cov`, which instruments tests with LLVM profiling and generates LCOV reports.


### PR DESCRIPTION
## Summary
Adds step 4 of the diffguard Codecov rollout: `docs/ci/coverage.md` documenting the claim boundary and separate proof lanes.

## CI economics
- **Default PR LEM impact:** None; documentation only.
- **Workflow touched:** None; documentation file.
- **Branch protection impact:** None; documentation does not affect checks.
- **Failure mode caught:** None; this is reference material.
- **Cheaper signal considered:** No; documentation is a durable contract.
- **Rollback path:** Delete `docs/ci/coverage.md`; no other file depends on it yet.

## Claim boundary
Codecov coverage is Rust execution-surface evidence only. It does **not** prove:
- diff parser correctness
- rule evaluation correctness
- inline suppression correctness
- renderer completeness (SARIF, JUnit, Checkstyle, GitLab, CSV, TSV, sensor)
- LSP diagnostic correctness
- false-positive baseline or trend correctness
- mutation adequacy
- fuzz robustness
- release readiness

Those are separate proof lanes (test, conformance, golden, mutation, fuzz).

## Documentation structure
- **What it answers:** execution-surface coverage
- **What it does not answer:** 9 separate categories of non-coverage claims
- **Separate proof lanes:** test, conformance, golden, mutation, fuzz
- **Workflow triggers:** main pushes, manual, labeled PRs
- **Configuration:** target, threshold, comments, annotations
- **Artifacts:** coverage.json, coverage.txt, lcov.info, coverage-receipt.json
- **Tool:** cargo-llvm-cov with LLVM profiling

## Validation
- [x] documentation is clear and exhaustive
- [x] claim boundary is explicit and specific
- [x] separate proof lanes are documented
- [x] no trailing whitespace or formatting issues

---
_Generated by [Claude Code](https://claude.ai/code/session_01VboXJ243Rjf8hJFzcdVJWE)_