### PR TITLE
fix(diffguard-core): propagate GlobSetBuilder error instead of panicking

### DIFF
--- a/crates/diffguard-core/src/check.rs
+++ b/crates/diffguard-core/src/check.rs
@@ -79,6 +79,8 @@ pub enum PathFilterError {
         glob: String,
         source: globset::Error,
     },
+    #[error("failed to build path filter glob set: {source}")]
+    GlobSetBuild { source: globset::Error },
 }
 
 /// Run a policy check over a unified diff text.
@@ -265,7 +267,8 @@ fn compile_filter_globs(globs: &[String]) -> Result<GlobSet, PathFilterError> {
         })?;
         b.add(glob);
     }
-    Ok(b.build().expect("globset build should succeed"))
+    b.build()
+        .map_err(|source| PathFilterError::GlobSetBuild { source })
 }
 
 /// Filter a rule based on tag criteria in the plan.
@@ -436,6 +439,9 @@ mod tests {
         let err = compile_filter_globs(&["[".to_string()]).unwrap_err();
         match err {
             PathFilterError::InvalidGlob { glob, .. } => assert_eq!(glob, "["),
+            PathFilterError::GlobSetBuild { .. } => {
+                panic!("expected InvalidGlob, got GlobSetBuild")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #1475.

`compile_filter_globs` in `diffguard-core/src/check.rs` called `.expect("globset build should succeed")` on `GlobSetBuilder::build()`. That function already returns `Result<GlobSet, PathFilterError>`, so a build failure was being turned into a panic instead of a propagated error — exactly the pattern this codebase is migrating away from (ADR-0404, `rust.no_unwrap`).

## Changes

- Add `PathFilterError::GlobSetBuild { source: globset::Error }` variant.
- Replace `Ok(b.build().expect(...))` with `b.build().map_err(|source| PathFilterError::GlobSetBuild { source })`, mirroring how `Glob::new()` errors are mapped two lines above.
- Update the existing exhaustive match in `compile_filter_globs_rejects_invalid` to cover the new variant (the test still asserts the invalid-glob path).

In practice the build call rarely fails because each `Glob::new()` is validated up front, but using `.expect()` on a `Result`-returning call is a latent panic and a code-smell — surfacing it as `PathFilterError::GlobSetBuild` lets callers handle the failure normally.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p diffguard-core` — 141 + 6 tests pass
- [x] `cargo clippy -p diffguard-core --all-targets -- -D warnings` — clean
- [x] Existing `compile_filter_globs_rejects_invalid` test still passes (now exhaustive over both variants)


---
_Generated by [Claude Code](https://claude.ai/code/session_0189TM6MPwLpMzsFMdB8VwN9)_