### PR TITLE
chore: gitignore .claude/ harness state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ artifacts/
 .hermes/
 # Agent findings and plans — not part of code history
 findings/
+# Claude Code worktrees and per-session state — harness-local, not code history
+.claude/
 # Mutation testing output
 mutants.out*/
 # Vim swap files


### PR DESCRIPTION
## Summary

Claude Code creates per-session state under `.claude/` (worktrees, transcripts) that is intentionally local to the harness and should not be tracked in source. This mirrors the existing pattern of ignoring `.hermes/` and `findings/`.

Closes #1609 (tracked alongside sibling coverage PRs).

Branch convention exemption: the diff is one config line, so a `chore/` prefix would have been more idiomatic, but keeping the branch name aligned with the coverage series for grouping.

## Test plan
- [x] `git status` is clean after the change while agent worktrees are present in `.claude/worktrees/`.
- [x] No code changes — no build/test impact.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QGDM4DbRfQGXqgbyPicJn6)_