### PR TITLE
refactor(diffguard-core): split run_check into SRP submodules

### DIFF
--- a/crates/diffguard-core/src/check/annotations.rs
+++ b/crates/diffguard-core/src/check/annotations.rs
@@ -1,0 +1,74 @@
+use diffguard_types::Finding;
+
+pub(super) fn render_annotations(findings: &[Finding]) -> Vec<String> {
+    findings
+        .iter()
+        .map(|f| {
+            let level = match f.severity {
+                diffguard_types::Severity::Info => "notice",
+                diffguard_types::Severity::Warn => "warning",
+                diffguard_types::Severity::Error => "error",
+            };
+            format!(
+                "::{level} file={path},line={line}::{rule} {msg}",
+                level = level,
+                path = f.path,
+                line = f.line,
+                rule = f.rule_id,
+                msg = f.message
+            )
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn test_finding(severity: diffguard_types::Severity) -> Finding {
+        Finding {
+            rule_id: "test.rule".to_string(),
+            severity,
+            message: "Test message".to_string(),
+            path: "src/lib.rs".to_string(),
+            line: 42,
+            column: Some(3),
+            match_text: "match".to_string(),
+            snippet: "let x = match;".to_string(),
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(100))]
+
+        #[test]
+        fn property_annotations_format_matches_expected(
+            severity in prop_oneof![Just(diffguard_types::Severity::Info), Just(diffguard_types::Severity::Warn), Just(diffguard_types::Severity::Error)],
+            line in 1u32..1000,
+        ) {
+            let mut finding = test_finding(severity);
+            finding.line = line;
+
+            let annotations = render_annotations(&[finding.clone()]);
+            prop_assert_eq!(annotations.len(), 1);
+
+            let level = match severity {
+                diffguard_types::Severity::Info => "notice",
+                diffguard_types::Severity::Warn => "warning",
+                diffguard_types::Severity::Error => "error",
+            };
+
+            let expected = format!(
+                "::{level} file={path},line={line}::{rule} {msg}",
+                level = level,
+                path = finding.path,
+                line = finding.line,
+                rule = finding.rule_id,
+                msg = finding.message
+            );
+
+            prop_assert_eq!(annotations[0].as_str(), expected.as_str());
+        }
+    }
+}

--- a/crates/diffguard-core/src/check/diff_prep.rs
+++ b/crates/diffguard-core/src/check/diff_prep.rs
@@ -1,0 +1,33 @@
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use diffguard_diff::{DiffLine, parse_unified_diff};
+
+use super::CheckPlan;
+use super::path_filter::compile_filter_globs;
+
+/// Parse the unified diff and apply secondary filters: path globs, allowed-lines, dedup.
+///
+/// Returns the filtered, deduplicated list of diff lines ready for evaluation.
+pub(super) fn prepare_diff_lines(
+    plan: &CheckPlan,
+    diff_text: &str,
+) -> Result<Vec<DiffLine>, anyhow::Error> {
+    let (mut diff_lines, _stats) = parse_unified_diff(diff_text, plan.scope)?;
+
+    if !plan.path_filters.is_empty() {
+        let filters = compile_filter_globs(&plan.path_filters)?;
+        diff_lines.retain(|l| filters.is_match(Path::new(&l.path)));
+    }
+
+    if let Some(allowed_lines) = &plan.allowed_lines {
+        diff_lines.retain(|l| allowed_lines.contains(&(l.path.clone(), l.line)));
+    }
+
+    // Multiple diff sources (or unusual diffs) can contain duplicates for the same
+    // path/line/content tuple. Keep first occurrence to preserve deterministic ordering.
+    let mut seen = BTreeSet::<(String, u32, String)>::new();
+    diff_lines.retain(|l| seen.insert((l.path.clone(), l.line, l.content.clone())));
+
+    Ok(diff_lines)
+}

--- a/crates/diffguard-core/src/check/false_positive.rs
+++ b/crates/diffguard-core/src/check/false_positive.rs
@@ -1,0 +1,62 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use diffguard_types::{Finding, VerdictCounts};
+
+use crate::fingerprint::compute_fingerprint;
+
+/// Per-rule tally of false-positive filtering: (total_filtered, info, warn, error).
+pub(super) type PerRuleFalsePositive = BTreeMap<String, (u32, u32, u32, u32)>;
+
+pub(super) struct FalsePositiveOutcome {
+    pub kept_findings: Vec<Finding>,
+    pub adjusted_counts: VerdictCounts,
+    pub false_positive_findings: u32,
+    pub per_rule: PerRuleFalsePositive,
+}
+
+/// Drop findings whose fingerprints appear in `false_positive_fingerprints`, adjusting
+/// verdict counts and recording per-rule false-positive tallies for analytics.
+pub(super) fn apply_false_positive_filter(
+    findings: Vec<Finding>,
+    initial_counts: &VerdictCounts,
+    false_positive_fingerprints: &BTreeSet<String>,
+) -> FalsePositiveOutcome {
+    let mut kept = Vec::with_capacity(findings.len());
+    let mut adjusted = initial_counts.clone();
+    let mut total_fp = 0u32;
+    let mut per_rule = PerRuleFalsePositive::new();
+
+    for finding in findings {
+        let fingerprint = compute_fingerprint(&finding);
+        if false_positive_fingerprints.contains(&fingerprint) {
+            total_fp = total_fp.saturating_add(1);
+            let entry = per_rule
+                .entry(finding.rule_id.clone())
+                .or_insert((0, 0, 0, 0));
+            entry.0 = entry.0.saturating_add(1);
+            match finding.severity {
+                diffguard_types::Severity::Info => {
+                    adjusted.info = adjusted.info.saturating_sub(1);
+                    entry.1 = entry.1.saturating_add(1);
+                }
+                diffguard_types::Severity::Warn => {
+                    adjusted.warn = adjusted.warn.saturating_sub(1);
+                    entry.2 = entry.2.saturating_add(1);
+                }
+                diffguard_types::Severity::Error => {
+                    adjusted.error = adjusted.error.saturating_sub(1);
+                    entry.3 = entry.3.saturating_add(1);
+                }
+            }
+            continue;
+        }
+        kept.push(finding);
+    }
+
+    FalsePositiveOutcome {
+        kept_findings: kept,
+        adjusted_counts: adjusted,
+        false_positive_findings: total_fp,
+        per_rule,
+    }
+}

--- a/crates/diffguard-core/src/check/mod.rs
+++ b/crates/diffguard-core/src/check/mod.rs
@@ -1,19 +1,27 @@
-use std::collections::{BTreeMap, BTreeSet};
-use std::path::Path;
+//! Check orchestration.
+//!
+//! `run_check` ties together the pipeline: diff prep → rule filtering → evaluation →
+//! false-positive filtering → verdict → receipt assembly → output rendering.
+//!
+//! Sub-modules each own one step of that pipeline.
 
-use globset::{Glob, GlobSet, GlobSetBuilder};
+mod annotations;
+mod diff_prep;
+mod false_positive;
+mod path_filter;
+mod rule_filter;
+mod rule_hits;
+mod verdict;
 
-use diffguard_diff::parse_unified_diff;
+use std::collections::BTreeSet;
+
 use diffguard_domain::{
     DirectoryRuleOverride, InputLine, RuleOverrideMatcher, compile_rules,
     evaluate_lines_with_overrides_and_language,
 };
-use diffguard_types::{
-    CheckReceipt, DiffMeta, FailOn, Finding, REASON_TRUNCATED, ToolMeta, Verdict, VerdictCounts,
-    VerdictStatus,
-};
+use diffguard_types::{CheckReceipt, DiffMeta, FailOn, REASON_TRUNCATED, ToolMeta, Verdict};
 
-use crate::fingerprint::compute_fingerprint;
+pub use path_filter::PathFilterError;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CheckPlan {
@@ -72,15 +80,6 @@ pub struct RuleHitStat {
     pub false_positive: u32,
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum PathFilterError {
-    #[error("invalid path filter glob '{glob}': {source}")]
-    InvalidGlob {
-        glob: String,
-        source: globset::Error,
-    },
-}
-
 /// Run a policy check over a unified diff text.
 ///
 /// # Errors
@@ -95,27 +94,12 @@ pub fn run_check(
     config: &diffguard_types::ConfigFile,
     diff_text: &str,
 ) -> Result<CheckRun, anyhow::Error> {
-    let (mut diff_lines, _stats) = parse_unified_diff(diff_text, plan.scope)?;
+    let diff_lines = diff_prep::prepare_diff_lines(plan, diff_text)?;
 
-    if !plan.path_filters.is_empty() {
-        let filters = compile_filter_globs(&plan.path_filters)?;
-        diff_lines.retain(|l| filters.is_match(Path::new(&l.path)));
-    }
-
-    if let Some(allowed_lines) = &plan.allowed_lines {
-        diff_lines.retain(|l| allowed_lines.contains(&(l.path.clone(), l.line)));
-    }
-
-    // Multiple diff sources (or unusual diffs) can contain duplicates for the same
-    // path/line/content tuple. Keep first occurrence to preserve deterministic ordering.
-    let mut seen = BTreeSet::<(String, u32, String)>::new();
-    diff_lines.retain(|l| seen.insert((l.path.clone(), l.line, l.content.clone())));
-
-    // Filter rules by tags
     let filtered_rules: Vec<_> = config
         .rule
         .iter()
-        .filter(|r| filter_rule_by_tags(r, plan))
+        .filter(|r| rule_filter::filter_rule_by_tags(r, plan))
         .cloned()
         .collect();
 
@@ -133,55 +117,19 @@ pub fn run_check(
         lines,
         &rules,
         plan.max_findings,
-        {
-            if plan.directory_overrides.is_empty() {
-                None
-            } else {
-                Some(&override_matcher)
-            }
+        if plan.directory_overrides.is_empty() {
+            None
+        } else {
+            Some(&override_matcher)
         },
         plan.force_language.as_deref(),
     );
 
-    let mut filtered_findings = Vec::with_capacity(evaluation.findings.len());
-    let mut adjusted_counts = evaluation.counts.clone();
-    let mut false_positive_findings = 0u32;
-    let mut per_rule_false_positive = BTreeMap::<String, (u32, u32, u32, u32)>::new();
-
-    for finding in evaluation.findings {
-        let fingerprint = compute_fingerprint(&finding);
-        if plan.false_positive_fingerprints.contains(&fingerprint) {
-            false_positive_findings = false_positive_findings.saturating_add(1);
-            let entry = per_rule_false_positive
-                .entry(finding.rule_id.clone())
-                .or_insert((0, 0, 0, 0));
-            entry.0 = entry.0.saturating_add(1);
-            match finding.severity {
-                diffguard_types::Severity::Info => {
-                    adjusted_counts.info = adjusted_counts.info.saturating_sub(1);
-                    entry.1 = entry.1.saturating_add(1);
-                }
-                diffguard_types::Severity::Warn => {
-                    adjusted_counts.warn = adjusted_counts.warn.saturating_sub(1);
-                    entry.2 = entry.2.saturating_add(1);
-                }
-                diffguard_types::Severity::Error => {
-                    adjusted_counts.error = adjusted_counts.error.saturating_sub(1);
-                    entry.3 = entry.3.saturating_add(1);
-                }
-            }
-            continue;
-        }
-        filtered_findings.push(finding);
-    }
-
-    let verdict_status = if adjusted_counts.error > 0 {
-        VerdictStatus::Fail
-    } else if adjusted_counts.warn > 0 {
-        VerdictStatus::Warn
-    } else {
-        VerdictStatus::Pass
-    };
+    let fp_outcome = false_positive::apply_false_positive_filter(
+        evaluation.findings,
+        &evaluation.counts,
+        &plan.false_positive_fingerprints,
+    );
 
     let mut reasons: Vec<String> = Vec::new();
     if evaluation.truncated_findings > 0 {
@@ -202,47 +150,19 @@ pub fn run_check(
             files_scanned: evaluation.files_scanned,
             lines_scanned: evaluation.lines_scanned,
         },
-        findings: filtered_findings,
+        findings: fp_outcome.kept_findings,
         verdict: Verdict {
-            status: verdict_status,
-            counts: adjusted_counts,
+            status: verdict::compute_verdict_status(&fp_outcome.adjusted_counts),
+            counts: fp_outcome.adjusted_counts,
             reasons,
         },
         timing: None,
     };
 
     let markdown = crate::render::render_markdown_for_receipt(&receipt);
-    let annotations = render_annotations(&receipt.findings);
-
-    let exit_code = compute_exit_code(plan.fail_on, &receipt.verdict.counts);
-
-    let mut rule_hits: Vec<RuleHitStat> = evaluation
-        .rule_hits
-        .into_iter()
-        .map(|s| RuleHitStat {
-            rule_id: s.rule_id,
-            total: s.total,
-            emitted: s.emitted,
-            suppressed: s.suppressed,
-            info: s.info,
-            warn: s.warn,
-            error: s.error,
-            false_positive: 0,
-        })
-        .collect();
-
-    if !per_rule_false_positive.is_empty() {
-        for stat in &mut rule_hits {
-            if let Some((filtered, info, warn, error)) = per_rule_false_positive.get(&stat.rule_id)
-            {
-                stat.emitted = stat.emitted.saturating_sub(*filtered);
-                stat.info = stat.info.saturating_sub(*info);
-                stat.warn = stat.warn.saturating_sub(*warn);
-                stat.error = stat.error.saturating_sub(*error);
-                stat.false_positive = stat.false_positive.saturating_add(*filtered);
-            }
-        }
-    }
+    let annotations = annotations::render_annotations(&receipt.findings);
+    let exit_code = verdict::compute_exit_code(plan.fail_on, &receipt.verdict.counts);
+    let rule_hits = rule_hits::build_rule_hits(evaluation.rule_hits, &fp_outcome.per_rule);
 
     Ok(CheckRun {
         receipt,
@@ -252,101 +172,14 @@ pub fn run_check(
         truncated_findings: evaluation.truncated_findings,
         rules_evaluated,
         rule_hits,
-        false_positive_findings,
+        false_positive_findings: fp_outcome.false_positive_findings,
     })
-}
-
-fn compile_filter_globs(globs: &[String]) -> Result<GlobSet, PathFilterError> {
-    let mut b = GlobSetBuilder::new();
-    for g in globs {
-        let glob = Glob::new(g).map_err(|e| PathFilterError::InvalidGlob {
-            glob: g.clone(),
-            source: e,
-        })?;
-        b.add(glob);
-    }
-    Ok(b.build().expect("globset build should succeed"))
-}
-
-/// Filter a rule based on tag criteria in the plan.
-///
-/// - If `only_tags` is non-empty, the rule must have at least one matching tag.
-/// - `enable_tags` is additive to `only_tags` (a rule matching either set is included).
-/// - If `disable_tags` is non-empty and the rule has any matching tag, it's excluded.
-fn filter_rule_by_tags(rule: &diffguard_types::RuleConfig, plan: &CheckPlan) -> bool {
-    // If only_tags is specified, allow rules matching only_tags OR enable_tags.
-    // This keeps enable_tags additive rather than restrictive on its own.
-    if !plan.only_tags.is_empty() {
-        let has_only_tag = rule
-            .tags
-            .iter()
-            .any(|t| plan.only_tags.iter().any(|ot| ot.eq_ignore_ascii_case(t)));
-        let has_enabled_tag = !plan.enable_tags.is_empty()
-            && rule
-                .tags
-                .iter()
-                .any(|t| plan.enable_tags.iter().any(|et| et.eq_ignore_ascii_case(t)));
-        if !has_only_tag && !has_enabled_tag {
-            return false;
-        }
-    }
-
-    // If disable_tags is specified, exclude rules that have any matching tag
-    if !plan.disable_tags.is_empty() {
-        let has_disabled_tag = rule.tags.iter().any(|t| {
-            plan.disable_tags
-                .iter()
-                .any(|dt| dt.eq_ignore_ascii_case(t))
-        });
-        if has_disabled_tag {
-            return false;
-        }
-    }
-
-    true
-}
-
-fn compute_exit_code(fail_on: FailOn, counts: &VerdictCounts) -> i32 {
-    if matches!(fail_on, FailOn::Never) {
-        return 0;
-    }
-
-    if counts.error > 0 {
-        return 2;
-    }
-
-    if matches!(fail_on, FailOn::Warn) && counts.warn > 0 {
-        return 3;
-    }
-
-    0
-}
-
-fn render_annotations(findings: &[Finding]) -> Vec<String> {
-    findings
-        .iter()
-        .map(|f| {
-            let level = match f.severity {
-                diffguard_types::Severity::Info => "notice",
-                diffguard_types::Severity::Warn => "warning",
-                diffguard_types::Severity::Error => "error",
-            };
-            format!(
-                "::{level} file={path},line={line}::{rule} {msg}",
-                level = level,
-                path = f.path,
-                line = f.line,
-                rule = f.rule_id,
-                msg = f.message
-            )
-        })
-        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use proptest::prelude::*;
+    use diffguard_types::{Finding, VerdictCounts, VerdictStatus};
 
     fn test_finding(severity: diffguard_types::Severity) -> Finding {
         Finding {
@@ -412,30 +245,6 @@ mod tests {
             force_language: None,
             allowed_lines: None,
             false_positive_fingerprints: BTreeSet::new(),
-        }
-    }
-
-    #[test]
-    fn exit_code_semantics() {
-        let mut counts = VerdictCounts::default();
-        assert_eq!(compute_exit_code(FailOn::Error, &counts), 0);
-        assert_eq!(compute_exit_code(FailOn::Warn, &counts), 0);
-
-        counts.warn = 1;
-        assert_eq!(compute_exit_code(FailOn::Error, &counts), 0);
-        assert_eq!(compute_exit_code(FailOn::Warn, &counts), 3);
-
-        counts.error = 1;
-        assert_eq!(compute_exit_code(FailOn::Error, &counts), 2);
-        assert_eq!(compute_exit_code(FailOn::Warn, &counts), 2);
-        assert_eq!(compute_exit_code(FailOn::Never, &counts), 0);
-    }
-
-    #[test]
-    fn compile_filter_globs_rejects_invalid() {
-        let err = compile_filter_globs(&["[".to_string()]).unwrap_err();
-        match err {
-            PathFilterError::InvalidGlob { glob, .. } => assert_eq!(glob, "["),
         }
     }
 
@@ -671,39 +480,6 @@ diff --git a/src/lib.rs b/src/lib.rs
         assert!(run.receipt.verdict.reasons.is_empty());
     }
 
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(100))]
-
-        #[test]
-        fn property_annotations_format_matches_expected(
-            severity in prop_oneof![Just(diffguard_types::Severity::Info), Just(diffguard_types::Severity::Warn), Just(diffguard_types::Severity::Error)],
-            line in 1u32..1000,
-        ) {
-            let mut finding = test_finding(severity);
-            finding.line = line;
-
-            let annotations = render_annotations(&[finding.clone()]);
-            prop_assert_eq!(annotations.len(), 1);
-
-            let level = match severity {
-                diffguard_types::Severity::Info => "notice",
-                diffguard_types::Severity::Warn => "warning",
-                diffguard_types::Severity::Error => "error",
-            };
-
-            let expected = format!(
-                "::{level} file={path},line={line}::{rule} {msg}",
-                level = level,
-                path = finding.path,
-                line = finding.line,
-                rule = finding.rule_id,
-                msg = finding.message
-            );
-
-            prop_assert_eq!(annotations[0].as_str(), expected.as_str());
-        }
-    }
-
     #[test]
     fn snapshot_annotations_with_multiple_severities() {
         let findings = vec![
@@ -711,7 +487,7 @@ diff --git a/src/lib.rs b/src/lib.rs
             test_finding(diffguard_types::Severity::Warn),
             test_finding(diffguard_types::Severity::Error),
         ];
-        let annotations = render_annotations(&findings);
+        let annotations = super::annotations::render_annotations(&findings);
         insta::assert_snapshot!(annotations.join("\n"));
     }
 
@@ -750,130 +526,5 @@ diff --git a/src/lib.rs b/src/lib.rs
 
         let json = serde_json::to_string_pretty(&receipt).expect("serialize receipt");
         insta::assert_snapshot!(json);
-    }
-
-    // =========================================================================
-    // Tag filtering tests
-    // =========================================================================
-
-    fn make_rule_with_tags(id: &str, tags: Vec<&str>) -> diffguard_types::RuleConfig {
-        diffguard_types::RuleConfig {
-            id: id.to_string(),
-            description: String::new(),
-            severity: diffguard_types::Severity::Warn,
-            message: "Test message".to_string(),
-            languages: vec![],
-            patterns: vec!["test".to_string()],
-            paths: vec![],
-            exclude_paths: vec![],
-            ignore_comments: false,
-            ignore_strings: false,
-            match_mode: Default::default(),
-            multiline: false,
-            multiline_window: None,
-            context_patterns: vec![],
-            context_window: None,
-            escalate_patterns: vec![],
-            escalate_window: None,
-            escalate_to: None,
-            depends_on: vec![],
-            help: None,
-            url: None,
-            tags: tags.into_iter().map(|s| s.to_string()).collect(),
-            test_cases: vec![],
-        }
-    }
-
-    #[test]
-    fn filter_rule_by_tags_no_filters() {
-        let rule = make_rule_with_tags("test.rule", vec!["debug"]);
-        let plan = test_plan(100, FailOn::Error, vec![]);
-        assert!(filter_rule_by_tags(&rule, &plan));
-    }
-
-    #[test]
-    fn filter_rule_by_tags_only_tags_matches() {
-        let rule = make_rule_with_tags("test.rule", vec!["debug", "safety"]);
-        let mut plan = test_plan(100, FailOn::Error, vec![]);
-        plan.only_tags = vec!["debug".to_string()];
-        assert!(filter_rule_by_tags(&rule, &plan));
-    }
-
-    #[test]
-    fn filter_rule_by_tags_only_tags_no_match() {
-        let rule = make_rule_with_tags("test.rule", vec!["security"]);
-        let mut plan = test_plan(100, FailOn::Error, vec![]);
-        plan.only_tags = vec!["debug".to_string()];
-        assert!(!filter_rule_by_tags(&rule, &plan));
-    }
-
-    #[test]
-    fn filter_rule_by_tags_only_tags_case_insensitive() {
-        let rule = make_rule_with_tags("test.rule", vec!["DEBUG"]);
-        let mut plan = test_plan(100, FailOn::Error, vec![]);
-        plan.only_tags = vec!["debug".to_string()];
-        assert!(filter_rule_by_tags(&rule, &plan));
-    }
-
-    #[test]
-    fn filter_rule_by_tags_enable_tags_additive_with_only_tags() {
-        let rule = make_rule_with_tags("test.rule", vec!["security"]);
-        let mut plan = test_plan(100, FailOn::Error, vec![]);
-        plan.only_tags = vec!["debug".to_string()];
-        plan.enable_tags = vec!["security".to_string()];
-
-        assert!(filter_rule_by_tags(&rule, &plan));
-    }
-
-    #[test]
-    fn filter_rule_by_tags_enable_tags_no_effect_without_only_tags() {
-        let rule = make_rule_with_tags("test.rule", vec!["style"]);
-        let mut plan = test_plan(100, FailOn::Error, vec![]);
-        plan.enable_tags = vec!["security".to_string()];
-
-        assert!(filter_rule_by_tags(&rule, &plan));
-    }
-
-    #[test]
-    fn filter_rule_by_tags_disable_tags_excludes() {
-        let rule = make_rule_with_tags("test.rule", vec!["debug"]);
-        let mut plan = test_plan(100, FailOn::Error, vec![]);
-        plan.disable_tags = vec!["debug".to_string()];
-        assert!(!filter_rule_by_tags(&rule, &plan));
-    }
-
-    #[test]
-    fn filter_rule_by_tags_disable_tags_no_match() {
-        let rule = make_rule_with_tags("test.rule", vec!["safety"]);
-        let mut plan = test_plan(100, FailOn::Error, vec![]);
-        plan.disable_tags = vec!["debug".to_string()];
-        assert!(filter_rule_by_tags(&rule, &plan));
-    }
-
-    #[test]
-    fn filter_rule_by_tags_combined_filters() {
-        // Rule has both "security" and "debug" tags
-        let rule = make_rule_with_tags("test.rule", vec!["security", "debug"]);
-
-        // Only security rules, but exclude debug rules
-        let mut plan = test_plan(100, FailOn::Error, vec![]);
-        plan.only_tags = vec!["security".to_string()];
-        plan.disable_tags = vec!["debug".to_string()];
-
-        // Should be excluded because it has a disabled tag
-        assert!(!filter_rule_by_tags(&rule, &plan));
-    }
-
-    #[test]
-    fn filter_rule_by_tags_rule_without_tags() {
-        let rule = make_rule_with_tags("test.rule", vec![]);
-        let mut plan = test_plan(100, FailOn::Error, vec![]);
-        plan.only_tags = vec!["debug".to_string()];
-        // Rule without tags doesn't match only_tags filter
-        assert!(!filter_rule_by_tags(&rule, &plan));
-
-        // But with no filters, it should pass
-        plan.only_tags.clear();
-        assert!(filter_rule_by_tags(&rule, &plan));
     }
 }

--- a/crates/diffguard-core/src/check/path_filter.rs
+++ b/crates/diffguard-core/src/check/path_filter.rs
@@ -1,0 +1,35 @@
+use globset::{Glob, GlobSet, GlobSetBuilder};
+
+#[derive(Debug, thiserror::Error)]
+pub enum PathFilterError {
+    #[error("invalid path filter glob '{glob}': {source}")]
+    InvalidGlob {
+        glob: String,
+        source: globset::Error,
+    },
+}
+
+pub(super) fn compile_filter_globs(globs: &[String]) -> Result<GlobSet, PathFilterError> {
+    let mut b = GlobSetBuilder::new();
+    for g in globs {
+        let glob = Glob::new(g).map_err(|e| PathFilterError::InvalidGlob {
+            glob: g.clone(),
+            source: e,
+        })?;
+        b.add(glob);
+    }
+    Ok(b.build().expect("globset build should succeed"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compile_filter_globs_rejects_invalid() {
+        let err = compile_filter_globs(&["[".to_string()]).unwrap_err();
+        match err {
+            PathFilterError::InvalidGlob { glob, .. } => assert_eq!(glob, "["),
+        }
+    }
+}

--- a/crates/diffguard-core/src/check/rule_filter.rs
+++ b/crates/diffguard-core/src/check/rule_filter.rs
@@ -1,0 +1,186 @@
+use super::CheckPlan;
+
+/// Filter a rule based on tag criteria in the plan.
+///
+/// - If `only_tags` is non-empty, the rule must have at least one matching tag.
+/// - `enable_tags` is additive to `only_tags` (a rule matching either set is included).
+/// - If `disable_tags` is non-empty and the rule has any matching tag, it's excluded.
+pub(super) fn filter_rule_by_tags(rule: &diffguard_types::RuleConfig, plan: &CheckPlan) -> bool {
+    // If only_tags is specified, allow rules matching only_tags OR enable_tags.
+    // This keeps enable_tags additive rather than restrictive on its own.
+    if !plan.only_tags.is_empty() {
+        let has_only_tag = rule
+            .tags
+            .iter()
+            .any(|t| plan.only_tags.iter().any(|ot| ot.eq_ignore_ascii_case(t)));
+        let has_enabled_tag = !plan.enable_tags.is_empty()
+            && rule
+                .tags
+                .iter()
+                .any(|t| plan.enable_tags.iter().any(|et| et.eq_ignore_ascii_case(t)));
+        if !has_only_tag && !has_enabled_tag {
+            return false;
+        }
+    }
+
+    // If disable_tags is specified, exclude rules that have any matching tag
+    if !plan.disable_tags.is_empty() {
+        let has_disabled_tag = rule.tags.iter().any(|t| {
+            plan.disable_tags
+                .iter()
+                .any(|dt| dt.eq_ignore_ascii_case(t))
+        });
+        if has_disabled_tag {
+            return false;
+        }
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::CheckPlan;
+    use super::*;
+    use diffguard_types::FailOn;
+    use std::collections::BTreeSet;
+
+    fn make_rule_with_tags(id: &str, tags: Vec<&str>) -> diffguard_types::RuleConfig {
+        diffguard_types::RuleConfig {
+            id: id.to_string(),
+            description: String::new(),
+            severity: diffguard_types::Severity::Warn,
+            message: "Test message".to_string(),
+            languages: vec![],
+            patterns: vec!["test".to_string()],
+            paths: vec![],
+            exclude_paths: vec![],
+            ignore_comments: false,
+            ignore_strings: false,
+            match_mode: Default::default(),
+            multiline: false,
+            multiline_window: None,
+            context_patterns: vec![],
+            context_window: None,
+            escalate_patterns: vec![],
+            escalate_window: None,
+            escalate_to: None,
+            depends_on: vec![],
+            help: None,
+            url: None,
+            tags: tags.into_iter().map(|s| s.to_string()).collect(),
+            test_cases: vec![],
+        }
+    }
+
+    fn test_plan() -> CheckPlan {
+        CheckPlan {
+            base: "base".to_string(),
+            head: "head".to_string(),
+            scope: diffguard_types::Scope::Added,
+            diff_context: 0,
+            fail_on: FailOn::Error,
+            max_findings: 100,
+            path_filters: vec![],
+            only_tags: vec![],
+            enable_tags: vec![],
+            disable_tags: vec![],
+            directory_overrides: vec![],
+            force_language: None,
+            allowed_lines: None,
+            false_positive_fingerprints: BTreeSet::new(),
+        }
+    }
+
+    #[test]
+    fn no_filters_keeps_rule() {
+        let rule = make_rule_with_tags("test.rule", vec!["debug"]);
+        assert!(filter_rule_by_tags(&rule, &test_plan()));
+    }
+
+    #[test]
+    fn only_tags_matches() {
+        let rule = make_rule_with_tags("test.rule", vec!["debug", "safety"]);
+        let mut plan = test_plan();
+        plan.only_tags = vec!["debug".to_string()];
+        assert!(filter_rule_by_tags(&rule, &plan));
+    }
+
+    #[test]
+    fn only_tags_no_match() {
+        let rule = make_rule_with_tags("test.rule", vec!["security"]);
+        let mut plan = test_plan();
+        plan.only_tags = vec!["debug".to_string()];
+        assert!(!filter_rule_by_tags(&rule, &plan));
+    }
+
+    #[test]
+    fn only_tags_case_insensitive() {
+        let rule = make_rule_with_tags("test.rule", vec!["DEBUG"]);
+        let mut plan = test_plan();
+        plan.only_tags = vec!["debug".to_string()];
+        assert!(filter_rule_by_tags(&rule, &plan));
+    }
+
+    #[test]
+    fn enable_tags_additive_with_only_tags() {
+        let rule = make_rule_with_tags("test.rule", vec!["security"]);
+        let mut plan = test_plan();
+        plan.only_tags = vec!["debug".to_string()];
+        plan.enable_tags = vec!["security".to_string()];
+
+        assert!(filter_rule_by_tags(&rule, &plan));
+    }
+
+    #[test]
+    fn enable_tags_no_effect_without_only_tags() {
+        let rule = make_rule_with_tags("test.rule", vec!["style"]);
+        let mut plan = test_plan();
+        plan.enable_tags = vec!["security".to_string()];
+
+        assert!(filter_rule_by_tags(&rule, &plan));
+    }
+
+    #[test]
+    fn disable_tags_excludes() {
+        let rule = make_rule_with_tags("test.rule", vec!["debug"]);
+        let mut plan = test_plan();
+        plan.disable_tags = vec!["debug".to_string()];
+        assert!(!filter_rule_by_tags(&rule, &plan));
+    }
+
+    #[test]
+    fn disable_tags_no_match() {
+        let rule = make_rule_with_tags("test.rule", vec!["safety"]);
+        let mut plan = test_plan();
+        plan.disable_tags = vec!["debug".to_string()];
+        assert!(filter_rule_by_tags(&rule, &plan));
+    }
+
+    #[test]
+    fn combined_filters() {
+        // Rule has both "security" and "debug" tags
+        let rule = make_rule_with_tags("test.rule", vec!["security", "debug"]);
+
+        // Only security rules, but exclude debug rules
+        let mut plan = test_plan();
+        plan.only_tags = vec!["security".to_string()];
+        plan.disable_tags = vec!["debug".to_string()];
+
+        // Should be excluded because it has a disabled tag
+        assert!(!filter_rule_by_tags(&rule, &plan));
+    }
+
+    #[test]
+    fn rule_without_tags() {
+        let rule = make_rule_with_tags("test.rule", vec![]);
+        let mut plan = test_plan();
+        plan.only_tags = vec!["debug".to_string()];
+        // Rule without tags doesn't match only_tags filter
+        assert!(!filter_rule_by_tags(&rule, &plan));
+
+        // But with no filters, it should pass
+        plan.only_tags.clear();
+        assert!(filter_rule_by_tags(&rule, &plan));
+    }
+}

--- a/crates/diffguard-core/src/check/rule_hits.rs
+++ b/crates/diffguard-core/src/check/rule_hits.rs
@@ -1,0 +1,39 @@
+use diffguard_domain::RuleHitStat as DomainRuleHitStat;
+
+use super::RuleHitStat;
+use super::false_positive::PerRuleFalsePositive;
+
+/// Map domain-layer per-rule stats to core `RuleHitStat`, subtracting any false-positive
+/// filtering recorded in `per_rule_fp` so that final analytics reflect the user's view.
+pub(super) fn build_rule_hits(
+    domain_hits: Vec<DomainRuleHitStat>,
+    per_rule_fp: &PerRuleFalsePositive,
+) -> Vec<RuleHitStat> {
+    let mut rule_hits: Vec<RuleHitStat> = domain_hits
+        .into_iter()
+        .map(|s| RuleHitStat {
+            rule_id: s.rule_id,
+            total: s.total,
+            emitted: s.emitted,
+            suppressed: s.suppressed,
+            info: s.info,
+            warn: s.warn,
+            error: s.error,
+            false_positive: 0,
+        })
+        .collect();
+
+    if !per_rule_fp.is_empty() {
+        for stat in &mut rule_hits {
+            if let Some((filtered, info, warn, error)) = per_rule_fp.get(&stat.rule_id) {
+                stat.emitted = stat.emitted.saturating_sub(*filtered);
+                stat.info = stat.info.saturating_sub(*info);
+                stat.warn = stat.warn.saturating_sub(*warn);
+                stat.error = stat.error.saturating_sub(*error);
+                stat.false_positive = stat.false_positive.saturating_add(*filtered);
+            }
+        }
+    }
+
+    rule_hits
+}

--- a/crates/diffguard-core/src/check/snapshots/diffguard_core__check__tests__snapshot_annotations_with_multiple_severities.snap
+++ b/crates/diffguard-core/src/check/snapshots/diffguard_core__check__tests__snapshot_annotations_with_multiple_severities.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/diffguard-core/src/check.rs
+source: crates/diffguard-core/src/check/mod.rs
 expression: "annotations.join(\"\\n\")"
 ---
 ::notice file=src/lib.rs,line=42::test.rule Test message

--- a/crates/diffguard-core/src/check/snapshots/diffguard_core__check__tests__snapshot_json_receipt_pretty.snap
+++ b/crates/diffguard-core/src/check/snapshots/diffguard_core__check__tests__snapshot_json_receipt_pretty.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/diffguard-core/src/check.rs
+source: crates/diffguard-core/src/check/mod.rs
 expression: json
 ---
 {

--- a/crates/diffguard-core/src/check/verdict.rs
+++ b/crates/diffguard-core/src/check/verdict.rs
@@ -1,0 +1,73 @@
+use diffguard_types::{FailOn, VerdictCounts, VerdictStatus};
+
+pub(super) fn compute_verdict_status(counts: &VerdictCounts) -> VerdictStatus {
+    if counts.error > 0 {
+        VerdictStatus::Fail
+    } else if counts.warn > 0 {
+        VerdictStatus::Warn
+    } else {
+        VerdictStatus::Pass
+    }
+}
+
+pub(super) fn compute_exit_code(fail_on: FailOn, counts: &VerdictCounts) -> i32 {
+    if matches!(fail_on, FailOn::Never) {
+        return 0;
+    }
+
+    if counts.error > 0 {
+        return 2;
+    }
+
+    if matches!(fail_on, FailOn::Warn) && counts.warn > 0 {
+        return 3;
+    }
+
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exit_code_semantics() {
+        let mut counts = VerdictCounts::default();
+        assert_eq!(compute_exit_code(FailOn::Error, &counts), 0);
+        assert_eq!(compute_exit_code(FailOn::Warn, &counts), 0);
+
+        counts.warn = 1;
+        assert_eq!(compute_exit_code(FailOn::Error, &counts), 0);
+        assert_eq!(compute_exit_code(FailOn::Warn, &counts), 3);
+
+        counts.error = 1;
+        assert_eq!(compute_exit_code(FailOn::Error, &counts), 2);
+        assert_eq!(compute_exit_code(FailOn::Warn, &counts), 2);
+        assert_eq!(compute_exit_code(FailOn::Never, &counts), 0);
+    }
+
+    #[test]
+    fn verdict_status_pass_when_clean() {
+        let counts = VerdictCounts::default();
+        assert_eq!(compute_verdict_status(&counts), VerdictStatus::Pass);
+    }
+
+    #[test]
+    fn verdict_status_warn_when_warns() {
+        let counts = VerdictCounts {
+            warn: 1,
+            ..Default::default()
+        };
+        assert_eq!(compute_verdict_status(&counts), VerdictStatus::Warn);
+    }
+
+    #[test]
+    fn verdict_status_fail_when_errors_outrank_warns() {
+        let counts = VerdictCounts {
+            warn: 1,
+            error: 1,
+            ..Default::default()
+        };
+        assert_eq!(compute_verdict_status(&counts), VerdictStatus::Fail);
+    }
+}


### PR DESCRIPTION
## Summary

`run_check` in `diffguard-core/src/check.rs` was a 165-line function doing seven distinct things: diff parsing & filtering, rule tag filtering, evaluation dispatch, false-positive filtering, verdict computation, receipt assembly, and output rendering. Promote `check.rs` to a `check/` module directory and extract each concern into its own SRP submodule:

| Submodule | Single responsibility |
|---|---|
| `diff_prep` | Parse the unified diff, apply path globs + allowed-lines + dedup |
| `rule_filter` | Tag-based rule selection (`only_tags` / `enable_tags` / `disable_tags`) |
| `false_positive` | Fingerprint-based filtering + per-rule analytics tallies |
| `verdict` | Verdict status + exit code from counts |
| `annotations` | GitHub Actions annotation rendering |
| `rule_hits` | Map domain stats → core stats, apply FP adjustments |
| `path_filter` | Glob compilation + `PathFilterError` |

`run_check` now reads as a 7-step pipeline. The orchestrator went from ~165 lines of intermixed logic to ~85 lines that call each step by name.

## Public API

Unchanged. `CheckPlan`, `CheckRun`, `RuleHitStat`, `PathFilterError`, and `run_check` are still re-exported from `diffguard_core` at the same paths. `sensor_api.rs` continues to import `crate::check::{CheckPlan, run_check}`; the CLI and LSP need no edits.

## Snapshots

`diffguard_core__check__tests__snapshot_*.snap` files moved from `src/snapshots/` to `src/check/snapshots/` to match `insta`'s source-relative discovery (file bodies byte-identical, only `source:` header path updated).

## Tests

- Tag-filter tests moved next to `rule_filter`
- Exit-code tests moved next to `verdict` (plus three new tests covering `compute_verdict_status` directly)
- Annotations proptest moved next to `annotations`
- The `run_check`-level integration tests and the two existing snapshot tests stay in `check/mod.rs` so snapshot file names remain stable

## Test plan

- [x] `cargo build -p diffguard-core` — clean
- [x] `cargo test -p diffguard-core` — 144 lib + all integration tests pass (3 added verdict tests)
- [x] `cargo test --workspace` — all green except 26 pre-existing `diffguard --bin` failures unrelated to this change (sandbox can't run `git commit`; reproduces on `main` worktree)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01KZsEfWFoW6ToEozNHdbhKQ)_